### PR TITLE
Set katsubushi.Version by git tag automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
-GIT_VER := $(shell git describe --tags)
+GIT_VER := $(shell git describe --tags | sed -e 's/^v//')
 
 all: katsubushi
 
 katsubushi: cmd/katsubushi/katsubushi
 
 cmd/katsubushi/katsubushi: *.go cmd/katsubushi/*.go
-	cd cmd/katsubushi && go build
+	cd cmd/katsubushi && go build -ldflags "-X github.com/kayac/go-katsubushi.Version=${GIT_VER}"
 
-.PHONEY: clean test packages
+
+.PHONEY: clean test packages install
+install: cmd/katsubushi/katsubushi
+	install cmd/katsubushi/katsubushi ${GOPATH}/bin
+
 clean:
 	rm -rf cmd/katsubushi/katsubushi pkg/*
 

--- a/app.go
+++ b/app.go
@@ -16,9 +16,9 @@ import (
 	log "gopkg.in/Sirupsen/logrus.v0"
 )
 
-const (
+var (
 	// Version number
-	Version = "1.0.0"
+	Version = "development"
 )
 
 var (


### PR DESCRIPTION
I made a mistak on release for v1.1.0. I forgot update a `Version` variable.

