### PR TITLE
Add options for max-worker-id and min-worker-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ This option is specified, katsubushi will assign an unique worker ID via Redis.
 
 All katsubushi process for your service must use a same Redis URL.
 
+### -min-worker-id -max-worker-id
+
+These options work with `-redis`.
+
+If we use multi katsubushi clusters, worker-id range for each clusters must not be overlapped. katsubushi can specify the worker-id range by these options.
+
 ### -port
 
 Optional.

--- a/app_test.go
+++ b/app_test.go
@@ -450,7 +450,7 @@ func TestAppCancel(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		cancel()
+		cancelAndWait(cancel)
 		// disconnect by peer after canceled
 		res, err := client.Command("VERSION")
 		if err == nil && len(res) > 0 { // response returned


### PR DESCRIPTION
If we use multi katsubushi clusters, worker-id range for each clusters must not be overlapped. 
katsubushi can specify the worker-id range by these options.