### PR TITLE
Reduce memory allocation

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func newTestApp(t *testing.T) *App {
+func newTestApp(t testing.TB) *App {
 	app, err := NewApp(getNextWorkerID())
 	if err != nil {
 		t.Fatal(err)
@@ -38,7 +38,7 @@ func newTestApp(t *testing.T) *App {
 	return app
 }
 
-func newTestAppAndListenTCP(ctx context.Context, t *testing.T) *App {
+func newTestAppAndListenTCP(ctx context.Context, t testing.TB) *App {
 	app := newTestApp(t)
 
 	go app.ListenTCP(ctx, ":0")
@@ -47,7 +47,7 @@ func newTestAppAndListenTCP(ctx context.Context, t *testing.T) *App {
 	return app
 }
 
-func newTestAppAndListenSock(ctx context.Context, t *testing.T) (*App, string) {
+func newTestAppAndListenSock(ctx context.Context, t testing.TB) (*App, string) {
 	app := newTestApp(t)
 
 	tmpDir, _ := ioutil.TempDir("", "go-katsubushi-")

--- a/memcache.go
+++ b/memcache.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"io"
 	"net"
 	"strconv"
 	"sync"
@@ -53,7 +54,7 @@ func (c *memcacheClient) Get(key string) (uint64, error) {
 	c.conn.SetDeadline(time.Now().Add(c.timeout))
 	c.rw.Write(memdGets)
 	c.rw.Write(memdSpc)
-	c.rw.Write([]byte(key))
+	io.WriteString(c.rw, key)
 	c.rw.Write(memdSep)
 	if err := c.rw.Flush(); err != nil {
 		c.close()
@@ -89,7 +90,7 @@ func (c *memcacheClient) GetMulti(keys []string) ([]uint64, error) {
 	c.rw.Write(memdGets)
 	for _, key := range keys {
 		c.rw.Write(memdSpc)
-		c.rw.Write([]byte(key))
+		io.WriteString(c.rw, key)
 	}
 	c.rw.Write(memdSep)
 	if err := c.rw.Flush(); err != nil {


### PR DESCRIPTION
Before
```
$ go test -bench "(Fetch|App)" -benchmem
goos: darwin
goarch: amd64
pkg: github.com/kayac/go-katsubushi
BenchmarkApp-4               	  100000	     19032 ns/op	    1297 B/op	       9 allocs/op
BenchmarkAppSock-4           	  200000	      7864 ns/op	    1296 B/op	       9 allocs/op
BenchmarkClientFetch-4       	  100000	     20694 ns/op	    4816 B/op	      14 allocs/op
BenchmarkGoMemcacheFetch-4   	  100000	     22426 ns/op	    2642 B/op	      34 allocs/op
```

After
```
$ go test -bench "(Fetch|App)" -benchmem
goos: darwin
goarch: amd64
pkg: github.com/kayac/go-katsubushi
BenchmarkApp-4               	  100000	     19451 ns/op	    1185 B/op	       8 allocs/op
BenchmarkAppSock-4           	  200000	      7589 ns/op	    1185 B/op	       8 allocs/op
BenchmarkClientFetch-4       	  100000	     18636 ns/op	     592 B/op	      11 allocs/op
BenchmarkGoMemcacheFetch-4   	  100000	     21124 ns/op	    2530 B/op	      33 allocs/op
```