### PR TITLE
Fix race condition of STATS command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmd/katsubushi/katsubushi
 pkg/*
 !.gitkeep
+/vendor/

--- a/app.go
+++ b/app.go
@@ -53,7 +53,9 @@ type App struct {
 	// App will disconnect connection if there are no commands until idleTimeout.
 	idleTimeout time.Duration
 
-	startedAt        time.Time
+	startedAt time.Time
+
+	// these values are accessed atomically
 	currConnections  int64
 	totalConnections int64
 	cmdGet           int64
@@ -234,11 +236,11 @@ func (app *App) GetStats() MemdStats {
 		Uptime:           int64(now.Sub(app.startedAt).Seconds()),
 		Time:             time.Now().Unix(),
 		Version:          Version,
-		CurrConnections:  app.currConnections,
-		TotalConnections: app.totalConnections,
-		CmdGet:           app.cmdGet,
-		GetHits:          app.getHits,
-		GetMisses:        app.getMisses,
+		CurrConnections:  atomic.LoadInt64(&app.currConnections),
+		TotalConnections: atomic.LoadInt64(&app.totalConnections),
+		CmdGet:           atomic.LoadInt64(&app.cmdGet),
+		GetHits:          atomic.LoadInt64(&app.getHits),
+		GetMisses:        atomic.LoadInt64(&app.getMisses),
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -418,7 +418,7 @@ func parseStats(str string) (map[string]int64, error) {
 		return nil, fmt.Errorf("end of result != END %#v", lines)
 	}
 	if len(lines)-2 != len(stats) {
-		return nil, fmt.Errorf("includes invalid line %s", stats)
+		return nil, fmt.Errorf("includes invalid line %#v", stats)
 	}
 	return stats, nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -436,6 +437,51 @@ func TestAppEmptyCommand(t *testing.T) {
 	if !strings.HasPrefix(string(_resp), "ERROR") {
 		t.Errorf("expected ERROR got %s", _resp)
 	}
+}
+
+func TestAppStatsReaceCondition(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	app := newTestAppAndListenTCP(ctx, t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		client, err := newTestClient(app.Listener.Addr().String())
+		if err != nil {
+			t.Fatalf("Failed to connect to app: %s", err)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			client.Command("GET id")
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		client, err := newTestClient(app.Listener.Addr().String())
+		if err != nil {
+			t.Fatalf("Failed to connect to app: %s", err)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			client.Command("STATS")
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestAppCancel(t *testing.T) {

--- a/converter.go
+++ b/converter.go
@@ -2,18 +2,21 @@ package katsubushi
 
 import "time"
 
+// ToTime returns the time when id was generated.
 func ToTime(id uint64) time.Time {
 	ts := id >> (WorkerIDBits + SequenceBits)
 	d := time.Duration(int64(ts) * int64(time.Millisecond))
 	return Epoch.Add(d)
 }
 
+// ToID returns the minimum id which will be generated at time t.
 func ToID(t time.Time) uint64 {
 	d := t.Sub(Epoch)
 	ts := uint64(d.Nanoseconds()) / uint64(time.Millisecond)
 	return ts << (WorkerIDBits + SequenceBits)
 }
 
+// Dump returns the structure of id.
 func Dump(id uint64) (t time.Time, workerID uint64, sequense uint64) {
 	workerID = (id & (workerIDMask << SequenceBits)) >> SequenceBits
 	sequense = id & sequenseMask


### PR DESCRIPTION
There is race condition of STATS and GET commands.

```
$ go test -race
==================
WARNING: DATA RACE
Read at 0x00c4201161a8 by goroutine 71:
  github.com/kayac/go-katsubushi.(*App).GetStats()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:239 +0x2a0
  github.com/kayac/go-katsubushi.MemdCmdStats.Execute()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:352 +0x50
  github.com/kayac/go-katsubushi.(*MemdCmdStats).Execute()
      <autogenerated>:1 +0x7d
  github.com/kayac/go-katsubushi.(*App).handleConn()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:216 +0x65a

Previous write at 0x00c4201161a8 by goroutine 69:
  sync/atomic.AddInt64()
      /usr/local/go/src/runtime/race_amd64.s:276 +0xb
  github.com/kayac/go-katsubushi.(*App).BytesToCmd()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:274 +0x144
  github.com/kayac/go-katsubushi.(*App).handleConn()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:208 +0x47d

Goroutine 71 (running) created at:
  github.com/kayac/go-katsubushi.(*App).Listen()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:181 +0x48f
  github.com/kayac/go-katsubushi.(*App).ListenTCP()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:148 +0xdc

Goroutine 69 (running) created at:
  github.com/kayac/go-katsubushi.(*App).Listen()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:181 +0x48f
  github.com/kayac/go-katsubushi.(*App).ListenTCP()
      /Users/ichinose/src/github.com/kayac/go-katsubushi/app.go:148 +0xdc
==================
```