### PR TITLE
Remove SetIdleTimeout().

### DIFF
--- a/app.go
+++ b/app.go
@@ -66,33 +66,31 @@ type App struct {
 	getMisses        int64
 }
 
+// Option represents a App optional parameters.
+type Option struct {
+	WorkerID    uint
+	IdleTimeout *time.Duration
+}
+
 // NewApp create and returns new App instance.
-func NewApp(workerID uint) (*App, error) {
-	gen, err := NewGenerator(workerID)
+func NewApp(opt Option) (*App, error) {
+	gen, err := NewGenerator(opt.WorkerID)
 	if err != nil {
 		return nil, err
 	}
+	var timeout time.Duration
+	if opt.IdleTimeout != nil {
+		timeout = *opt.IdleTimeout
+	} else {
+		timeout = DefaultIdleTimeout
+	}
 
 	return &App{
-		idleTimeout: DefaultIdleTimeout,
+		idleTimeout: timeout,
 		gen:         gen,
 		startedAt:   time.Now(),
 		readyCh:     make(chan interface{}),
 	}, nil
-}
-
-// SetIdleTimeout sets duration before disconnect caused by idle networking.
-// To disable idle timeout, set 0.
-func (app *App) SetIdleTimeout(timeout int) error {
-	app.mu.Lock()
-	defer app.mu.Unlock()
-	if timeout < 0 {
-		return fmt.Errorf("timeout must be positive")
-	}
-
-	app.idleTimeout = time.Duration(timeout) * time.Second
-
-	return nil
 }
 
 // SetLogLevel sets log level.
@@ -299,8 +297,6 @@ func (app *App) BytesToCmd(data []byte) (cmd MemdCmd, err error) {
 }
 
 func (app *App) extendDeadline(conn net.Conn) {
-	app.mu.Lock()
-	defer app.mu.Unlock()
 	if app.idleTimeout == InfiniteIdleTimeout {
 		return
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,7 @@ import (
 func BenchmarkClientFetch(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := newTestAppAndListenTCP(ctx, b)
+	app := newTestAppAndListenTCP(ctx, b, nil)
 
 	b.ResetTimer()
 
@@ -32,7 +32,7 @@ func BenchmarkClientFetch(b *testing.B) {
 func BenchmarkGoMemcacheFetch(b *testing.B) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := newTestAppAndListenTCP(ctx, b)
+	app := newTestAppAndListenTCP(ctx, b, nil)
 
 	b.ResetTimer()
 
@@ -50,7 +50,7 @@ func BenchmarkGoMemcacheFetch(b *testing.B) {
 func TestClientFetch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := newTestAppAndListenTCP(ctx, t)
+	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
 	id, err := c.Fetch()
@@ -66,7 +66,7 @@ func TestClientFetch(t *testing.T) {
 func TestClientMulti(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := newTestAppAndListenTCP(ctx, t)
+	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
 	ids, err := c.FetchMulti(3)
@@ -87,8 +87,8 @@ func TestClientMulti(t *testing.T) {
 func TestClientFetchRetry(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	app := newTestAppAndListenTCP(ctx, t)
-	app.SetIdleTimeout(1)
+	to := time.Second
+	app := newTestAppAndListenTCP(ctx, t, &to)
 
 	c := NewClient(app.Listener.Addr().String())
 
@@ -108,11 +108,11 @@ func TestClientFetchRetry(t *testing.T) {
 func TestClientFetchBackup(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	app1 := newTestAppAndListenTCP(ctx1, t)
+	app1 := newTestAppAndListenTCP(ctx1, t, nil)
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
-	app2 := newTestAppAndListenTCP(ctx2, t)
+	app2 := newTestAppAndListenTCP(ctx2, t, nil)
 
 	c := NewClient(
 		app1.Listener.Addr().String(),
@@ -147,7 +147,7 @@ func TestClientFetchBackup(t *testing.T) {
 
 func TestClientFail(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	app := newTestAppAndListenTCP(ctx, t)
+	app := newTestAppAndListenTCP(ctx, t, nil)
 
 	c := NewClient(
 		app.Listener.Addr().String(),
@@ -164,7 +164,7 @@ func TestClientFail(t *testing.T) {
 
 func TestClientFailMulti(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	app := newTestAppAndListenTCP(ctx, t)
+	app := newTestAppAndListenTCP(ctx, t, nil)
 
 	c := NewClient(
 		app.Listener.Addr().String(),
@@ -181,10 +181,10 @@ func TestClientFailMulti(t *testing.T) {
 
 func TestClientFailBackup(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	app1 := newTestAppAndListenTCP(ctx1, t)
+	app1 := newTestAppAndListenTCP(ctx1, t, nil)
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
-	app2 := newTestAppAndListenTCP(ctx2, t)
+	app2 := newTestAppAndListenTCP(ctx2, t, nil)
 
 	c := NewClient(
 		app1.Listener.Addr().String(),
@@ -203,10 +203,10 @@ func TestClientFailBackup(t *testing.T) {
 
 func TestClientFailBackupMulti(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	app1 := newTestAppAndListenTCP(ctx1, t)
+	app1 := newTestAppAndListenTCP(ctx1, t, nil)
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
-	app2 := newTestAppAndListenTCP(ctx2, t)
+	app2 := newTestAppAndListenTCP(ctx2, t, nil)
 
 	c := NewClient(
 		app1.Listener.Addr().String(),

--- a/cmd/katsubushi/main.go
+++ b/cmd/katsubushi/main.go
@@ -132,11 +132,18 @@ func mainListener(ctx context.Context, wg *sync.WaitGroup, fn katsubushi.ListenF
 }
 
 func newKatsubushiListenFunc(kc *katsubushiConfig) (katsubushi.ListenFunc, string, error) {
-	app, err := katsubushi.NewApp(kc.workerID)
-	if err != nil {
-		return nil, "", err
+	var timeout time.Duration
+	if kc.idleTimeout == 0 {
+		timeout = katsubushi.InfiniteIdleTimeout
+	} else {
+		timeout = time.Duration(kc.idleTimeout) * time.Second
 	}
-	if err := app.SetIdleTimeout(kc.idleTimeout); err != nil {
+
+	app, err := katsubushi.NewApp(katsubushi.Option{
+		WorkerID:    kc.workerID,
+		IdleTimeout: &timeout,
+	})
+	if err != nil {
 		return nil, "", err
 	}
 	if kc.sockpath != "" {


### PR DESCRIPTION
idleTimeout is immutable variable in Katsubushi usecases practically.
But SetIdleTimeout() was exists because it had been needed in test cases only.

If idleTimeout becomes immutable truly, Katubushi can reduce lock to a mutex.