### PR TITLE
Fix goroutine leak.

### DIFF
--- a/app.go
+++ b/app.go
@@ -198,10 +198,11 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	atomic.AddInt64(&(app.totalConnections), 1)
 	atomic.AddInt64(&(app.currConnections), 1)
 	defer atomic.AddInt64(&(app.currConnections), -1)
-	defer conn.Close()
 
+	ctx2, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		<-ctx.Done()
+		<-ctx2.Done()
 		conn.Close()
 	}()
 

--- a/app.go
+++ b/app.go
@@ -197,13 +197,13 @@ func (app *App) Ready() chan interface{} {
 func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	atomic.AddInt64(&(app.totalConnections), 1)
 	atomic.AddInt64(&(app.currConnections), 1)
-	defer atomic.AddInt64(&(app.currConnections), -1)
 
 	ctx2, cancel := context.WithCancel(ctx)
 	defer cancel()
 	go func() {
 		<-ctx2.Done()
 		conn.Close()
+		atomic.AddInt64(&(app.currConnections), -1)
 	}()
 
 	app.extendDeadline(conn)


### PR DESCRIPTION
goroutine in handleConn() was leaked because the goroutine will be free only when a parent context(started with a main process) is done.

This PR ensure to free the goroutine at return from handleConn().