### PR TITLE
supported various options when `docker run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,8 @@ https://hub.docker.com/r/katsubushi/katsubushi/
 
 ```
 $ docker pull katsubushi/katsubushi
-$ docker run -p 11212:11212 katsubushi/katsubushi
-```
-
-If you want to specify `worker_id`, set by an environment variable.
-
-```
-$ docker run -e "worker_id=123" -p 11212:11212 katsubushi/katsubushi
+$ docker run -p 11212:11212 katsubushi/katsubushi -worker-id 1
+$ docker run -p 11212:11212 katsubushi/katsubushi -redis redis://your.redis.host:6379/0
 ```
 
 ## Usage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,4 +10,3 @@ RUN curl -sL https://github.com/kayac/go-katsubushi/releases/download/v1.4.3/kat
 
 EXPOSE 11212
 ENTRYPOINT ["/usr/local/bin/katsubushi"]
-CMD ["-worker-id", "1"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,6 @@ MAINTAINER Fujiwara Shunichiro <fujiwara.shunichiro@gmail.com>
 RUN apk --update add unzip curl && rm -rf /var/cache/apk/*
 RUN curl -sL https://github.com/kayac/go-katsubushi/releases/download/v1.4.3/katsubushi-1.4.3-linux-amd64.zip > /tmp/katsubushi-1.4.3-linux-amd64.zip && cd /tmp && unzip katsubushi-1.4.3-linux-amd64.zip && install katsubushi /usr/local/bin && rm -f /tmp/katsubushi*
 
-ENV worker_id 1
 EXPOSE 11212
-CMD ["sh", "-c", "exec /usr/local/bin/katsubushi -worker-id $worker_id"]
+ENTRYPOINT ["/usr/local/bin/katsubushi"]
+CMD ["-worker-id", "1"]


### PR DESCRIPTION
Changed `CMD` to `ENTRYPOINT` in Dockerfile.

Results are as follows:

```console
$ docker build -t mykatsubushi ./docker

# /usr/local/bin/katsubushi -worker-id 1
$ docker run -t mykatsubushi -worker-id 1

# /usr/local/bin/katsubushi -redis redis://localhost:6379/0
$ docker run -t mykatsubushi -redis redis://localhost:6379/0
```

ref: https://github.com/kayac/go-katsubushi/issues/31