### PR TITLE
Ignore errors after a server shutdown.

### DIFF
--- a/app.go
+++ b/app.go
@@ -269,6 +269,12 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		select {
+		case <-ctx.Done():
+			// shutting down
+			return
+		default:
+		}
 		if !deadline.IsZero() && time.Now().After(deadline) {
 			log.Debugf("deadline exceeded: %s", err)
 		} else {


### PR DESCRIPTION
When a listener shutdown, scanner.Err() of active connections return an error "use of closed network connection".

```
2018-06-22T05:07:27.255Z    WARN    go-katsubushi/app.go:275    error on scanning request: read tcp 127.0.0.1:11212->127.0.0.1:34972: use of closed network connection
```