### PR TITLE
docker image support apple m1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - name: setup QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: setup tools
       run: |
         mkdir ~/bin

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ packages:
 		goxz -pv="v${GIT_VER}" \
 			-build-ldflags="-s -w -X github.com/kayac/go-katsubushi.Version=${GIT_VER}" \
 			-os=darwin,linux \
-			-arch=amd64 \
+			-arch=amd64,arm64 \
 			-d=dist \
 			./cmd/katsubushi
 
@@ -32,9 +32,12 @@ release:
 	ghr -u kayac -r go-katsubushi -n "v${GIT_VER}" ${GIT_VER} dist/
 
 docker: clean packages
-	cd dist && tar xvf go-katsubushi_v${GIT_VER}_linux_amd64.tar.gz
-	docker build \
+	cd dist && \
+		tar xvf go-katsubushi_v${GIT_VER}_linux_amd64.tar.gz && \
+		tar xvf go-katsubushi_v${GIT_VER}_linux_arm64.tar.gz
+	docker buildx build \
 		--build-arg VERSION=v${GIT_VER} \
+		--platform linux/amd64,linux/arm64 \
 		-f docker/Dockerfile \
 		-t katsubushi/katsubushi:v${GIT_VER} \
 		.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM alpine:3.11.3
 ARG VERSION
-ADD dist/go-katsubushi_${VERSION}_linux_amd64/katsubushi /usr/local/bin/katsubushi
+ARG TARGETARCH
+ADD dist/go-katsubushi_${VERSION}_linux_${TARGETARCH}/katsubushi /usr/local/bin/katsubushi
 EXPOSE 11212
 ENTRYPOINT ["/usr/local/bin/katsubushi"]


### PR DESCRIPTION
Get a warning if run katsubushi on M1 mac.
```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

Then send to HUP signal and it will SEGV.
```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

There are resolved by Build multi-arch images with Buildx. https://docs.docker.com/desktop/multi-arch/

This pull request replaces `docker build` with `docker buildx build`.
But I think more easy to use [`docker/build-push-action@v2`](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md) ( My project use it so easy 😄 )