### PR TITLE
Fix worker id conflict in generator test

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -9,8 +9,7 @@ import (
 var nextWorkerID uint32
 
 func getNextWorkerID() uint {
-	atomic.AddUint32(&nextWorkerID, 1)
-	return uint(nextWorkerID)
+	return uint(atomic.AddUint32(&nextWorkerID, 1))
 }
 
 func TestInvalidWorkerID(t *testing.T) {


### PR DESCRIPTION
I noticed that worker id generator in a test (`getNextWorkerID`) can return duplicate ids.

For proof, run the following code for multiple times.
<details><summary>main.go</summary>

```go
package main

import (
	"fmt"
	"sync"
	"sync/atomic"
)

var nextWorkerID uint32

func getNextWorkerID() uint {
	atomic.AddUint32(&nextWorkerID, 1)
	return uint(nextWorkerID)
}

const total = 500

func main() {
	var wg sync.WaitGroup
	var m sync.Map
	for i := 0; i < total; i++ {
		wg.Add(1)
		go func() {
			defer wg.Done()
			id := getNextWorkerID()
			if _, loaded := m.LoadOrStore(id, 0); loaded {
				fmt.Printf("conflict: %d\n", id)
			}
		}()
	}
	wg.Wait()
	var cnt int
	m.Range(func(_, _ interface{}) bool { cnt++; return true })
	if cnt != total {
		fmt.Printf("map size: %d != %d\n", cnt, total)
	}
}
```
</details>

```
 $ for i in `seq 100`; do go run main.go; done
conflict: 454
map size: 499 != 500
conflict: 470
map size: 499 != 500
conflict: 181
map size: 499 != 500
```