### PR TITLE
Fix Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,13 @@ jobs:
   test:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         go:
           - 1.16
           - 1.17
           - 1.18.0-beta1
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/app.go
+++ b/app.go
@@ -8,6 +8,7 @@ import (
 	stdlog "log"
 	"net"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -152,7 +153,8 @@ type ListenFunc func(context.Context, string) error
 
 // ListenSock starts listen Unix Domain Socket on sockpath.
 func (app *App) ListenSock(ctx context.Context, sockpath string) error {
-	l, err := net.Listen("unix", sockpath)
+	// NOTE: gomemcache expect filepath contains slashes.
+	l, err := net.Listen("unix", filepath.ToSlash(sockpath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
gomemcached expect the path contains slash-separators for the UNIX socket file. (I wonder that you want to add Windows support)