### PR TITLE
add http-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,44 @@ VERSION 1.1.2
 
 Disconnect an established connection.
 
+## Protocol (HTTP)
+
+katsubushi also runs an HTTP server specified with `-http-port`.
+
+### GET /id
+
+Get a single ID.
+
+When `Accept` HTTP header is 'application/json', katsubushi will return an ID as JSON format as below.
+
+```json
+{"id":"1025441401866821632"}
+```
+
+Otherwise, katsubushi will return ID as test format.
+
+```
+1025441401866821632
+```
+
+### GET /ids?n=(number_of_ids)
+
+Get multiple IDs.
+
+When `Accept` HTTP header is 'application/json', katsubushi will return an IDs as JSON format as below.
+
+```json
+{"ids":["1025442579472195584","1025442579472195585","1025442579472195586"]}
+```
+
+Otherwise, katsubushi will return ID as test format delimiterd with "\n".
+
+```
+1025442579472195584
+1025442579472195585
+1025442579472195586
+```
+
 ## Algorithm
 
 katsubushi use algorithm like snowflake to generate ID.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ When `Accept` HTTP header is 'application/json', katsubushi will return an ID as
 {"id":"1025441401866821632"}
 ```
 
-Otherwise, katsubushi will return ID as test format.
+Otherwise, katsubushi will return ID as text format.
 
 ```
 1025441401866821632
@@ -132,7 +132,7 @@ When `Accept` HTTP header is 'application/json', katsubushi will return an IDs a
 {"ids":["1025442579472195584","1025442579472195585","1025442579472195586"]}
 ```
 
-Otherwise, katsubushi will return ID as test format delimiterd with "\n".
+Otherwise, katsubushi will return ID as text format delimiterd with "\n".
 
 ```
 1025442579472195584

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ Otherwise, katsubushi will return ID as text format delimiterd with "\n".
 1025442579472195586
 ```
 
+### GET /stats
+
+Returns a stats of katsubushi.
+
+This API returns a JSON always.
+
+```json
+{
+  "pid": 1859630,
+  "uptime": 50,
+  "time": 1664761614,
+  "version": "1.8.0",
+  "curr_connections": 1,
+  "total_connections": 5,
+  "cmd_get": 15,
+  "get_hits": 25,
+  "get_misses": 0
+}
+```
+
 ## Algorithm
 
 katsubushi use algorithm like snowflake to generate ID.

--- a/app.go
+++ b/app.go
@@ -431,15 +431,15 @@ type MemdValue struct {
 
 // MemdStats defines result of STATS command.
 type MemdStats struct {
-	Pid              int    `memd:"pid"`
-	Uptime           int64  `memd:"uptime"`
-	Time             int64  `memd:"time"`
-	Version          string `memd:"version"`
-	CurrConnections  int64  `memd:"curr_connections"`
-	TotalConnections int64  `memd:"total_connections"`
-	CmdGet           int64  `memd:"cmd_get"`
-	GetHits          int64  `memd:"get_hits"`
-	GetMisses        int64  `memd:"get_misses"`
+	Pid              int    `memd:"pid" json:"pid"`
+	Uptime           int64  `memd:"uptime" json:"uptime"`
+	Time             int64  `memd:"time" json:"time"`
+	Version          string `memd:"version" json:"version"`
+	CurrConnections  int64  `memd:"curr_connections" json:"curr_connections"`
+	TotalConnections int64  `memd:"total_connections" json:"total_connections"`
+	CmdGet           int64  `memd:"cmd_get" json:"cmd_get"`
+	GetHits          int64  `memd:"get_hits" json:"get_hits"`
+	GetMisses        int64  `memd:"get_misses" json:"get_misses"`
 }
 
 // WriteTo writes content of MemdValue to io.Writer.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,12 @@
+package katsubushi
+
+type Config struct {
+	WorkerID    uint
+	Port        int
+	IdleTimeout int
+	LogLevel    string
+	Sockpath    string
+
+	HTTPPort       int
+	HTTPPathPrefix string
+}

--- a/http.go
+++ b/http.go
@@ -1,0 +1,100 @@
+package katsubushi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	MaxHTTPBulkSize = 1000
+)
+
+func (app *App) RunHTTPServer(ctx context.Context, wg *sync.WaitGroup, port int) error {
+	defer wg.Done()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/id", app.httpGetSingleID)
+	mux.HandleFunc("/ids", app.httpGetMultiID)
+	log.Infof("Listening HTTP server at :%d", port)
+	s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: mux,
+	}
+	// shutdown
+	go func() {
+		<-ctx.Done()
+		log.Infof("Shutting down HTTP server")
+		s.Shutdown(ctx)
+	}()
+	return s.ListenAndServe()
+}
+
+func (app *App) httpGetSingleID(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	id, err := app.NextID()
+	if err != nil {
+		log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if strings.Contains(req.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"%d"}`, id)
+	} else {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, "%d", id)
+	}
+}
+
+func (app *App) httpGetMultiID(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var n int64
+	if ns := req.FormValue("n"); ns == "" {
+		n = 1
+	} else {
+		var err error
+		n, err = strconv.ParseInt(ns, 10, 64)
+		if err != nil {
+			log.Error(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+	if n > MaxHTTPBulkSize {
+		msg := fmt.Sprintf("too many IDs requested: %d, n should be smaller than %d", n, MaxHTTPBulkSize)
+		log.Error(msg)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(msg))
+		return
+	}
+	ids := make([]string, 0, n)
+	for i := int64(0); i < n; i++ {
+		id, err := app.NextID()
+		if err != nil {
+			log.Error(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		ids = append(ids, strconv.FormatUint(id, 10))
+	}
+	if strings.Contains(req.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(struct {
+			IDs []string `json:"ids"`
+		}{ids})
+	} else {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, strings.Join(ids, "\n"))
+	}
+}

--- a/http.go
+++ b/http.go
@@ -18,8 +18,8 @@ func (app *App) RunHTTPServer(ctx context.Context, wg *sync.WaitGroup, port int)
 	defer wg.Done()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/id", app.httpGetSingleID)
-	mux.HandleFunc("/ids", app.httpGetMultiID)
+	mux.HandleFunc("/id", app.HTTPGetSingleID)
+	mux.HandleFunc("/ids", app.HTTPGetMultiID)
 	log.Infof("Listening HTTP server at :%d", port)
 	s := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
@@ -34,7 +34,7 @@ func (app *App) RunHTTPServer(ctx context.Context, wg *sync.WaitGroup, port int)
 	return s.ListenAndServe()
 }
 
-func (app *App) httpGetSingleID(w http.ResponseWriter, req *http.Request) {
+func (app *App) HTTPGetSingleID(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -54,7 +54,7 @@ func (app *App) httpGetSingleID(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (app *App) httpGetMultiID(w http.ResponseWriter, req *http.Request) {
+func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return

--- a/http_test.go
+++ b/http_test.go
@@ -112,3 +112,42 @@ func TestHTTPMultiJSON(t *testing.T) {
 		}
 	}
 }
+
+func testHTTPStats(t *testing.T) (int64, int64) {
+	req := httptest.NewRequest("GET", "/stats", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	httpApp.HTTPGetStats(w, req)
+	if w.Code != 200 {
+		t.Errorf("status code should be 200 but %d", w.Code)
+	}
+	var s katsubushi.MemdStats
+	if err := json.NewDecoder(w.Body).Decode(&s); err != nil {
+		t.Errorf("failed to read body: %v", err)
+	}
+	t.Logf("%#v", s)
+	return s.CmdGet, s.GetHits
+}
+
+func TestHTTPStats(t *testing.T) {
+	TestHTTPSingle(t)
+	cmdGet1, getHits1 := testHTTPStats(t)
+
+	TestHTTPSingle(t)
+	cmdGet2, getHits2 := testHTTPStats(t)
+	if cmdGet2 != cmdGet1+1 {
+		t.Errorf("cmd_get should be incremented by 1 but %d", cmdGet2-cmdGet1)
+	}
+	if getHits2 != getHits1+1 {
+		t.Errorf("get_hits should be incremented by 1 but %d", getHits2-getHits1)
+	}
+
+	TestHTTPMulti(t)
+	cmdGet3, getHits3 := testHTTPStats(t)
+	if cmdGet3 != cmdGet2+1 {
+		t.Errorf("cmd_get should be incremented by 10 but %d", cmdGet3-cmdGet2)
+	}
+	if getHits3 != getHits2+10 {
+		t.Errorf("get_hits should be incremented by 10 but %d", getHits3-getHits2)
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,114 @@
+package katsubushi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/kayac/go-katsubushi"
+)
+
+var httpApp *katsubushi.App
+
+func init() {
+	var err error
+	httpApp, err = katsubushi.NewApp(katsubushi.Option{WorkerID: 80})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestHTTPSingle(t *testing.T) {
+	req := httptest.NewRequest("GET", "/id", nil)
+	w := httptest.NewRecorder()
+
+	httpApp.HTTPGetSingleID(w, req)
+	if w.Code != 200 {
+		t.Errorf("status code should be 200 but %d", w.Code)
+	}
+	b := new(bytes.Buffer)
+	if _, err := io.Copy(b, w.Body); err != nil {
+		t.Errorf("failed to read body: %v", err)
+	}
+	if id, err := strconv.ParseUint(b.String(), 10, 64); err != nil {
+		t.Errorf("body should be a number uint64: %v", err)
+	} else {
+		t.Logf("HTTP fetched single ID: %d", id)
+	}
+}
+
+func TestHTTPSingleJSON(t *testing.T) {
+	req := httptest.NewRequest("GET", "/id", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	httpApp.HTTPGetSingleID(w, req)
+	if w.Code != 200 {
+		t.Errorf("status code should be 200 but %d", w.Code)
+	}
+	v := struct {
+		ID string `json:"id"`
+	}{}
+	if err := json.NewDecoder(w.Body).Decode(&v); err != nil {
+		t.Errorf("failed to decode body: %v", err)
+	}
+	if id, err := strconv.ParseUint(v.ID, 10, 64); err != nil {
+		t.Errorf("body should be a number uint64: %v", err)
+	} else {
+		t.Logf("HTTP fetched single ID as JSON: %d", id)
+	}
+}
+
+func TestHTTPMulti(t *testing.T) {
+	req := httptest.NewRequest("GET", "/ids?n=10", nil)
+	w := httptest.NewRecorder()
+
+	httpApp.HTTPGetMultiID(w, req)
+	if w.Code != 200 {
+		t.Errorf("status code should be 200 but %d", w.Code)
+	}
+	b := new(bytes.Buffer)
+	if _, err := io.Copy(b, w.Body); err != nil {
+		t.Errorf("failed to read body: %v", err)
+	}
+	bs := bytes.Split(b.Bytes(), []byte("\n"))
+	if len(bs) != 10 {
+		t.Errorf("body should contain 10 lines but %d", len(bs))
+	}
+	for _, b := range bs {
+		if id, err := strconv.ParseUint(string(b), 10, 64); err != nil {
+			t.Errorf("body should be a number uint64: %v", err)
+		} else {
+			t.Logf("HTTP fetched ID: %d", id)
+		}
+	}
+}
+
+func TestHTTPMultiJSON(t *testing.T) {
+	req := httptest.NewRequest("GET", "/ids?n=10", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	httpApp.HTTPGetMultiID(w, req)
+	if w.Code != 200 {
+		t.Errorf("status code should be 200 but %d", w.Code)
+	}
+	v := struct {
+		IDs []string `json:"ids"`
+	}{}
+	if err := json.NewDecoder(w.Body).Decode(&v); err != nil {
+		t.Errorf("failed to decode body: %v", err)
+	}
+	if len(v.IDs) != 10 {
+		t.Errorf("body should contain 10 lines but %d", len(v.IDs))
+	}
+	for _, id := range v.IDs {
+		if i, err := strconv.ParseUint(id, 10, 64); err != nil {
+			t.Errorf("body should be a number uint64: %v", err)
+		} else {
+			t.Logf("HTTP fetched single ID as JSON: %d", i)
+		}
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -113,7 +113,7 @@ func TestHTTPMultiJSON(t *testing.T) {
 	}
 }
 
-func testHTTPStats(t *testing.T) (int64, int64) {
+func testHTTPStats(t *testing.T) *katsubushi.MemdStats {
 	req := httptest.NewRequest("GET", "/stats", nil)
 	req.Header.Set("Accept", "application/json")
 	w := httptest.NewRecorder()
@@ -126,28 +126,28 @@ func testHTTPStats(t *testing.T) (int64, int64) {
 		t.Errorf("failed to read body: %v", err)
 	}
 	t.Logf("%#v", s)
-	return s.CmdGet, s.GetHits
+	return &s
 }
 
 func TestHTTPStats(t *testing.T) {
 	TestHTTPSingle(t)
-	cmdGet1, getHits1 := testHTTPStats(t)
+	s1 := testHTTPStats(t)
 
 	TestHTTPSingle(t)
-	cmdGet2, getHits2 := testHTTPStats(t)
-	if cmdGet2 != cmdGet1+1 {
-		t.Errorf("cmd_get should be incremented by 1 but %d", cmdGet2-cmdGet1)
+	s2 := testHTTPStats(t)
+	if s2.CmdGet != s1.CmdGet+1 {
+		t.Errorf("cmd_get should be incremented by 1 but %d", s2.CmdGet-s1.CmdGet)
 	}
-	if getHits2 != getHits1+1 {
-		t.Errorf("get_hits should be incremented by 1 but %d", getHits2-getHits1)
+	if s2.GetHits != s1.GetHits+1 {
+		t.Errorf("get_hits should be incremented by 1 but %d", s2.GetHits-s1.GetHits)
 	}
 
 	TestHTTPMulti(t)
-	cmdGet3, getHits3 := testHTTPStats(t)
-	if cmdGet3 != cmdGet2+1 {
-		t.Errorf("cmd_get should be incremented by 10 but %d", cmdGet3-cmdGet2)
+	s3 := testHTTPStats(t)
+	if s3.CmdGet != s2.CmdGet+1 {
+		t.Errorf("cmd_get should be incremented by 10 but %d", s3.CmdGet-s2.CmdGet)
 	}
-	if getHits3 != getHits2+10 {
-		t.Errorf("get_hits should be incremented by 10 but %d", getHits3-getHits2)
+	if s3.GetHits != s2.GetHits+10 {
+		t.Errorf("get_hits should be incremented by 10 but %d", s3.GetHits-s2.GetHits)
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -1,0 +1,28 @@
+package katsubushi
+
+import (
+	"fmt"
+	"time"
+)
+
+func NewListenerFunc(kc *Config) (*App, ListenFunc, string, error) {
+	var timeout time.Duration
+	if kc.IdleTimeout == 0 {
+		timeout = InfiniteIdleTimeout
+	} else {
+		timeout = time.Duration(kc.IdleTimeout) * time.Second
+	}
+
+	app, err := NewApp(Option{
+		WorkerID:    kc.WorkerID,
+		IdleTimeout: &timeout,
+	})
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if kc.Sockpath != "" {
+		return app, app.ListenSock, kc.Sockpath, nil
+	} else {
+		return app, app.ListenTCP, fmt.Sprintf(":%d", kc.Port), nil
+	}
+}


### PR DESCRIPTION
## Protocol (HTTP)

katsubushi also runs an HTTP server specified with `-http-port`.

### GET /id

Get a single ID.

When `Accept` HTTP header is 'application/json', katsubushi will return an ID as JSON format as below.

```json
{"id":"1025441401866821632"}
```

Otherwise, katsubushi will return ID as text format.

```
1025441401866821632
```

### GET /ids?n=(number_of_ids)

Get multiple IDs.

When `Accept` HTTP header is 'application/json', katsubushi will return an IDs as JSON format as below.

```json
{"ids":["1025442579472195584","1025442579472195585","1025442579472195586"]}
```

Otherwise, katsubushi will return ID as text format delimiterd with "\n".

```
1025442579472195584
1025442579472195585
1025442579472195586
```
