### PR TITLE
add ctx to client.Fetch, httpClient.Fetch

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package katsubushi
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -36,13 +37,13 @@ func (c *Client) SetTimeout(t time.Duration) {
 }
 
 // Fetch fetches id from katsubushi
-func (c *Client) Fetch() (uint64, error) {
+func (c *Client) Fetch(ctx context.Context) (uint64, error) {
 	errs := errors.New("no servers available")
 	for _, mc := range c.memcacheClients {
 		var id uint64
 		err := retry.Retry(2, 0, func() error {
 			var _err error
-			id, _err = mc.Get("id")
+			id, _err = mc.Get(ctx, "id")
 			return _err
 		})
 		if err != nil {
@@ -55,7 +56,7 @@ func (c *Client) Fetch() (uint64, error) {
 }
 
 // FetchMulti fetches multiple ids from katsubushi
-func (c *Client) FetchMulti(n int) ([]uint64, error) {
+func (c *Client) FetchMulti(ctx context.Context, n int) ([]uint64, error) {
 	keys := make([]string, 0, n)
 
 	for i := 0; i < n; i++ {
@@ -68,7 +69,7 @@ func (c *Client) FetchMulti(n int) ([]uint64, error) {
 		var ids []uint64
 		err := retry.Retry(2, 0, func() error {
 			var _err error
-			ids, _err = mc.GetMulti(keys)
+			ids, _err = mc.GetMulti(ctx, keys)
 			return _err
 		})
 		if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ func BenchmarkClientFetch(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		c := NewClient(app.Listener.Addr().String())
 		for pb.Next() {
-			id, err := c.Fetch()
+			id, err := c.Fetch(context.Background())
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -53,7 +53,7 @@ func TestClientFetch(t *testing.T) {
 	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
-	id, err := c.Fetch()
+	id, err := c.Fetch(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestClientMulti(t *testing.T) {
 	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
-	ids, err := c.FetchMulti(3)
+	ids, err := c.FetchMulti(context.Background(), 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestClientFetchRetry(t *testing.T) {
 	c := NewClient(app.Listener.Addr().String())
 
 	for i := 0; i < 3; i++ {
-		id, err := c.Fetch()
+		id, err := c.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +121,7 @@ func TestClientFetchBackup(t *testing.T) {
 
 	{
 		// fetched from app1
-		id, err := c.Fetch()
+		id, err := c.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -135,7 +135,7 @@ func TestClientFetchBackup(t *testing.T) {
 
 	{
 		// fetched from app2
-		id, err := c.Fetch()
+		id, err := c.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -155,7 +155,7 @@ func TestClientFail(t *testing.T) {
 
 	cancelAndWait(cancel)
 
-	_, err := c.Fetch()
+	_, err := c.Fetch(context.Background())
 	if err == nil {
 		t.Error("must be failed")
 	}
@@ -172,7 +172,7 @@ func TestClientFailMulti(t *testing.T) {
 
 	cancelAndWait(cancel)
 
-	_, err := c.FetchMulti(3)
+	_, err := c.FetchMulti(context.Background(), 3)
 	if err == nil {
 		t.Error("must be failed")
 	}
@@ -194,7 +194,7 @@ func TestClientFailBackup(t *testing.T) {
 	cancelAndWait(cancel1)
 	cancelAndWait(cancel2)
 
-	_, err := c.Fetch()
+	_, err := c.Fetch(context.Background())
 	if err == nil {
 		t.Error("must be failed")
 	}
@@ -216,7 +216,7 @@ func TestClientFailBackupMulti(t *testing.T) {
 	cancelAndWait(cancel1)
 	cancelAndWait(cancel2)
 
-	_, err := c.FetchMulti(3)
+	_, err := c.FetchMulti(context.Background(), 3)
 	if err == nil {
 		t.Error("must be failed")
 	}
@@ -235,7 +235,7 @@ func TestClientTimeout(t *testing.T) {
 	c := NewClient(app.Listener.Addr().String())
 	c.SetTimeout(500 * time.Millisecond)
 
-	_, err := c.Fetch()
+	_, err := c.Fetch(context.Background())
 	if err == nil {
 		t.Error("timeout expected but err is nil")
 	}

--- a/http.go
+++ b/http.go
@@ -173,12 +173,12 @@ func (c *HTTPClient) SetTimeout(t time.Duration) {
 }
 
 // Fetch fetches id from katsubushi via HTTP
-func (c *HTTPClient) Fetch() (uint64, error) {
+func (c *HTTPClient) Fetch(ctx context.Context) (uint64, error) {
 	errs := errors.New("no servers available")
 	for _, u := range c.urls {
 		id, err := func(u *url.URL) (uint64, error) {
 			u.Path = fmt.Sprintf("/%sid", c.pathPrefix)
-			req, _ := http.NewRequest("GET", u.String(), nil)
+			req, _ := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 			resp, err := c.client.Do(req)
 			if err != nil {
 				return 0, err
@@ -210,14 +210,14 @@ func (c *HTTPClient) Fetch() (uint64, error) {
 }
 
 // FetchMulti fetches multiple ids from katsubushi via HTTP
-func (c *HTTPClient) FetchMulti(n int) ([]uint64, error) {
+func (c *HTTPClient) FetchMulti(ctx context.Context, n int) ([]uint64, error) {
 	errs := errors.New("no servers available")
 	ids := make([]uint64, 0, n)
 	for _, u := range c.urls {
 		ids, err := func(u *url.URL) ([]uint64, error) {
 			u.Path = fmt.Sprintf("/%sids", c.pathPrefix)
 			u.RawQuery = fmt.Sprintf("n=%d", n)
-			req, _ := http.NewRequest("GET", u.String(), nil)
+			req, _ := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 			resp, err := c.client.Do(req)
 			if err != nil {
 				return nil, err

--- a/http_test.go
+++ b/http_test.go
@@ -171,7 +171,7 @@ func TestHTTPSingleCS(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 10; i++ {
-		id, err := client.Fetch()
+		id, err := client.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -189,7 +189,7 @@ func TestHTTPMultiCS(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 10; i++ {
-		ids, err := client.FetchMulti(10)
+		ids, err := client.FetchMulti(context.Background(), 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -212,7 +212,7 @@ func BenchmarkHTTPClientFetch(b *testing.B) {
 		u := fmt.Sprintf("http://localhost:%d", httpPort)
 		c, _ := katsubushi.NewHTTPClient([]string{u}, "")
 		for pb.Next() {
-			id, err := c.Fetch()
+			id, err := c.Fetch(context.Background())
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
gRPC Client has `Fetch(ctx)`. Memcached and HTTP clients should have the same interface.