### PR TITLE
Migrate to goreleaser v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod download
@@ -26,7 +27,7 @@ release:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Env.NIGHTLY_VERSION }}"
+  version_template: "{{ .Env.NIGHTLY_VERSION }}"
 changelog:
   sort: asc
   filters:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ test:
 	go test -race
 
 packages:
-	goreleaser build --skip-validate --rm-dist
+	goreleaser build --skip=validate --clean
 
 packages-snapshot:
-	goreleaser build --skip-validate --rm-dist --snapshot
+	goreleaser build --skip=validate --clean --snapshot
 
 docker: clean packages
 	mv dist/go-katsubushi_linux_amd64_v1 dist/go-katsubushi_linux_amd64

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,6 @@
 FROM alpine:3.16.2
 ARG VERSION
 ARG TARGETARCH
-ADD dist/go-katsubushi_linux_${TARGETARCH}/katsubushi /usr/local/bin/katsubushi
+ADD dist/go-katsubushi_linux_${TARGETARCH}*/katsubushi /usr/local/bin/katsubushi
 EXPOSE 11212
 ENTRYPOINT ["/usr/local/bin/katsubushi"]


### PR DESCRIPTION
I migrated some settings according to the migration guide.  
https://goreleaser.com/blog/goreleaser-v2

before

```console
❯ goreleaser check # using the latest v1
  rm -rf ./dist/
  grep -iR '\--rm-dist' .
  grep -iR '\--skip-' .
  grep -iR '\--debug' .
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
./Makefile:     goreleaser build --skip-validate --rm-dist
./Makefile:     goreleaser build --skip-validate --rm-dist --snapshot
./Makefile:     goreleaser build --skip-validate --rm-dist
./Makefile:     goreleaser build --skip-validate --rm-dist --snapshot
```

after

```console
❯ goreleaser check # using the latest v1
  rm -rf ./dist/
  grep -iR '\--rm-dist' .
  grep -iR '\--skip-' .
  grep -iR '\--debug' .
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```
