### PR TITLE
Push latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ docker: clean packages
 		--platform linux/amd64,linux/arm64 \
 		-f docker/Dockerfile \
 		-t katsubushi/katsubushi:v${GIT_VER} \
+		-t katsubushi/katsubushi:latest \
 		-t ghcr.io/kayac/go-katsubushi:v${GIT_VER} \
 		.
 
@@ -45,6 +46,7 @@ docker-push:
 		--platform linux/amd64,linux/arm64 \
 		-f docker/Dockerfile \
 		-t katsubushi/katsubushi:v${GIT_VER} \
+		-t katsubushi/katsubushi:latest \
 		-t ghcr.io/kayac/go-katsubushi:v${GIT_VER} \
 		--push \
 		.


### PR DESCRIPTION
Currently, the Docker image tagged as `latest` on Docker Hub is outdated:
[https://hub.docker.com/layers/katsubushi/katsubushi/latest/images/sha256-b859e751559b2ec99450de51dcfb4eb36a14356c8cb90dd068001d70655b1a02](https://hub.docker.com/layers/katsubushi/katsubushi/latest/images/sha256-b859e751559b2ec99450de51dcfb4eb36a14356c8cb90dd068001d70655b1a02)

This image was pushed 6 years ago and contains katsubushi version v1.5.3.
NOTE: Current latest version is v2.0.4

```console
❯ docker run katsubushi/katsubushi:latest -version
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
katsubushi version: 1.5.3
```

<details>
<summary>Manifest</summary>

```console
❯ docker manifest inspect -v katsubushi/katsubushi:latest
{
        "Ref": "docker.io/katsubushi/katsubushi:latest",
        "Descriptor": {
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "digest": "sha256:b859e751559b2ec99450de51dcfb4eb36a14356c8cb90dd068001d70655b1a02",
                "size": 739,
                "platform": {
                        "architecture": "amd64",
                        "os": "linux"
                }
        },
        "Raw": "ewogICAic2NoZW1hVmVyc2lvbiI6IDIsCiAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5kaXN0cmlidXRpb24ubWFuaWZlc3QudjIranNvbiIsCiAgICJjb25maWciOiB7CiAgICAgICJtZWRpYVR5cGUiOiAiYXBwbGljYXRpb24vdm5kLmRvY2tlci5jb250YWluZXIuaW1hZ2UudjEranNvbiIsCiAgICAgICJzaXplIjogMjE1NCwKICAgICAgImRpZ2VzdCI6ICJzaGEyNTY6OTg3NDdiZmRmOGQyNDU1OTEyMDM1MWUxMDI5MTg3MDgxMWM1OGQxNDg0NDU2YmM4Yzk2MTZiZjY5ODBhY2U0OCIKICAgfSwKICAgImxheWVycyI6IFsKICAgICAgewogICAgICAgICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLAogICAgICAgICAic2l6ZSI6IDIxMDcwOTgsCiAgICAgICAgICJkaWdlc3QiOiAic2hhMjU2OjVkMjBjODA4Y2UxOTg1NjVmZjcwYjNlZDIzYTk5MWRkNDlhZmFjNDVkZWNlNjM0NzRiMjdjZTZlZDAzNmFkYzYiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwKICAgICAgICAgInNpemUiOiAyNTgzODU5LAogICAgICAgICAiZGlnZXN0IjogInNoYTI1Njo1ZjhlMWRlNTBmM2VmZGI5OGYzMDMwN2Y4NDM4MDk5N2VlOTlhMGQ2MmQ5ZDVmZTYxYTJmMzBiMzkwYzk0NzI5IgogICAgICB9CiAgIF0KfQ==",
        "SchemaV2Manifest": {
                "schemaVersion": 2,
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "config": {
                        "mediaType": "application/vnd.docker.container.image.v1+json",
                        "size": 2154,
                        "digest": "sha256:98747bfdf8d24559120351e10291870811c58d1484456bc8c9616bf6980ace48"
                },
                "layers": [
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 2107098,
                                "digest": "sha256:5d20c808ce198565ff70b3ed23a991dd49afac45dece63474b27ce6ed036adc6"
                        },
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 2583859,
                                "digest": "sha256:5f8e1de50f3efdb98f30307f84380997ee99a0d62d9d5fe61a2f30b390c94729"
                        }
                ]
        }
}
```

</details> 

This pull request updates the release build process to tag the image as `latest` and push it to Docker Hub accordingly.

