### PR TITLE
Replace zap with slog and maintain original log format

### DIFF
--- a/app.go
+++ b/app.go
@@ -7,22 +7,101 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 var (
-	logger, _ = zap.NewDevelopment()
-	log       = logger.Sugar()
+	logger *slog.Logger
 )
+
+// customHandler implements slog.Handler with custom formatting
+type customHandler struct {
+	h slog.Handler
+}
+
+func newCustomHandler(w io.Writer, level slog.Level) *customHandler {
+	opts := &slog.HandlerOptions{
+		Level: level,
+		AddSource: true,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Remove default keys as we'll format them ourselves
+			if a.Key == slog.TimeKey || a.Key == slog.LevelKey || a.Key == slog.SourceKey || a.Key == slog.MessageKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}
+	return &customHandler{
+		h: slog.NewTextHandler(w, opts),
+	}
+}
+
+func (h *customHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.h.Enabled(ctx, level)
+}
+
+func (h *customHandler) Handle(ctx context.Context, r slog.Record) error {
+	// Format: 2025-08-01T22:11:28.043+0900    INFO    go-katsubushi/grpc.go:94        Message
+	var buf []byte
+	
+	// Time
+	buf = r.Time.AppendFormat(buf, "2006-01-02T15:04:05.000-0700")
+	buf = append(buf, '\t')
+	
+	// Level
+	buf = append(buf, r.Level.String()...)
+	buf = append(buf, '\t')
+	
+	// Source location
+	if r.PC != 0 {
+		fs := runtime.CallersFrames([]uintptr{r.PC})
+		f, _ := fs.Next()
+		// Extract just the package/file.go:line from the full path
+		file := f.File
+		idx := strings.LastIndex(file, "/go-katsubushi/")
+		if idx >= 0 {
+			file = "go-katsubushi/" + file[idx+len("/go-katsubushi/"):]
+		}
+		buf = append(buf, file...)
+		buf = append(buf, ':')
+		buf = append(buf, strconv.Itoa(f.Line)...)
+		buf = append(buf, '\t')
+	}
+	
+	// Message
+	buf = append(buf, r.Message...)
+	
+	// Attributes
+	r.Attrs(func(a slog.Attr) bool {
+		buf = append(buf, ' ')
+		buf = append(buf, a.Key...)
+		buf = append(buf, '=')
+		buf = append(buf, fmt.Sprint(a.Value.Any())...)
+		return true
+	})
+	
+	buf = append(buf, '\n')
+	
+	_, err := os.Stderr.Write(buf)
+	return err
+}
+
+func (h *customHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &customHandler{h: h.h.WithAttrs(attrs)}
+}
+
+func (h *customHandler) WithGroup(name string) slog.Handler {
+	return &customHandler{h: h.h.WithGroup(name)}
+}
 
 var (
 	respError         = []byte("ERROR\r\n")
@@ -86,41 +165,40 @@ func NewAppWithGenerator(gen Generator, workerID uint) (*App, error) {
 	}, nil
 }
 
+func init() {
+	handler := newCustomHandler(os.Stderr, slog.LevelInfo)
+	logger = slog.New(handler)
+	slog.SetDefault(logger)
+}
+
 // SetLogLevel sets log level.
 // Log level must be one of debug, info, warning, error, fatal and panic.
 func SetLogLevel(str string) error {
-	conf := zap.Config{
-		Encoding:         "console",
-		EncoderConfig:    zap.NewDevelopmentEncoderConfig(),
-		OutputPaths:      []string{"stderr"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
+	var level slog.Level
 	switch str {
 	case "debug":
-		conf.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-		conf.Development = true
+		level = slog.LevelDebug
 	case "info":
-		conf.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+		level = slog.LevelInfo
 	case "warning":
-		conf.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
+		level = slog.LevelWarn
 	case "error":
-		conf.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
-	case "fatal":
-		conf.Level = zap.NewAtomicLevelAt(zap.FatalLevel)
-	case "panic":
-		conf.Level = zap.NewAtomicLevelAt(zap.PanicLevel)
+		level = slog.LevelError
+	case "fatal", "panic":
+		// slog doesn't have fatal/panic levels, use error
+		level = slog.LevelError
 	default:
 		return fmt.Errorf("invalid log level %s", str)
 	}
-	logger.Sync()
-	logger, _ = conf.Build()
-	log = logger.Sugar()
+	handler := newCustomHandler(os.Stderr, level)
+	logger = slog.New(handler)
+	slog.SetDefault(logger)
 	return nil
 }
 
 // StdLogger returns the standard logger.
 func StdLogger() *stdlog.Logger {
-	return zap.NewStdLog(logger)
+	return slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
 }
 
 func (app *App) RunServer(ctx context.Context, kc *Config) error {
@@ -162,9 +240,8 @@ func (app *App) ListenerTCP(addr string) (net.Listener, error) {
 
 // Serve starts a server.
 func (app *App) Serve(ctx context.Context, l net.Listener) error {
-	defer logger.Sync()
-	log.Infof("Listening server at %s", l.Addr().String())
-	log.Infof("Worker ID = %d", app.gen.WorkerID())
+	logger.Info("Listening server at " + l.Addr().String())
+	logger.Info("Worker ID = " + strconv.FormatUint(uint64(app.gen.WorkerID()), 10))
 
 	app.Listener = l
 	close(app.readyCh)
@@ -172,7 +249,7 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 	go func() {
 		<-ctx.Done()
 		if err := l.Close(); err != nil {
-			log.Warn(err)
+			logger.Warn("Failed to close listener", "error", err)
 		}
 	}()
 
@@ -181,14 +258,14 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				log.Info("Shutting down server")
+				logger.Info("Shutting down server")
 				return nil
 			default:
-				log.Warnf("Error on accept connection: %s", err)
+				logger.Warn("Error on accept connection", "error", err)
 				return err
 			}
 		}
-		log.Debugf("Connected from %s", conn.RemoteAddr().String())
+		logger.Debug("Connected from " + conn.RemoteAddr().String())
 
 		go app.handleConn(ctx, conn)
 	}
@@ -205,7 +282,7 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	go func() {
 		<-ctx2.Done()
 		conn.Close()
-		log.Debugf("Closed %s", conn.RemoteAddr().String())
+		logger.Debug("Closed " + conn.RemoteAddr().String())
 	}()
 
 	app.extendDeadline(conn)
@@ -214,14 +291,14 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	isBin, err := app.IsBinaryProtocol(bufReader)
 	if err != nil {
 		if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "i/o timeout") {
-			log.Debugf("Connection closed %s: %s", conn.RemoteAddr().String(), err)
+			logger.Debug("Connection closed", "remote", conn.RemoteAddr().String(), "error", err)
 			return
 		}
-		log.Errorf("error on read first byte to decide binary protocol or not: %s", err)
+		logger.Error("error on read first byte to decide binary protocol or not", "error", err)
 		return
 	}
 	if isBin {
-		log.Debug("binary protocol")
+		logger.Debug("binary protocol")
 		app.RespondToBinary(bufReader, conn)
 		return
 	}
@@ -232,26 +309,26 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	for scanner.Scan() {
 		deadline, err = app.extendDeadline(conn)
 		if err != nil {
-			log.Warnf("error on set deadline: %s", err)
+			logger.Warn("error on set deadline", "error", err)
 			return
 		}
 		cmd, err := app.BytesToCmd(scanner.Bytes())
 		if err != nil {
 			if err := app.writeError(conn); err != nil {
-				log.Warnf("error on write error: %s", err)
+				logger.Warn("error on write error", "error", err)
 				return
 			}
 			continue
 		}
 		if err := cmd.Execute(app, w); err != nil {
 			if err != io.EOF {
-				log.Warnf("error on execute cmd %s: %s", cmd, err)
+				logger.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
 		if err := w.Flush(); err != nil {
 			if err != io.EOF {
-				log.Warnf("error on cmd %s write to conn: %s", cmd, err)
+				logger.Warn("error on cmd write to conn", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
@@ -264,9 +341,9 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 		default:
 		}
 		if !deadline.IsZero() && time.Now().After(deadline) {
-			log.Debugf("deadline exceeded: %s", err)
+			logger.Debug("deadline exceeded", "error", err)
 		} else {
-			log.Warnf("error on scanning request: %s", err)
+			logger.Warn("error on scanning request", "error", err)
 		}
 	}
 }
@@ -290,7 +367,7 @@ func (app *App) GetStats() MemdStats {
 func (app *App) writeError(conn io.Writer) (err error) {
 	_, err = conn.Write(respError)
 	if err != nil {
-		log.Warn(err)
+		logger.Warn("Failed to write error response", "error", err)
 	}
 
 	return
@@ -362,14 +439,14 @@ func (cmd *MemdCmdGet) Execute(app *App, conn io.Writer) error {
 	for i := range cmd.Keys {
 		id, err := app.NextID()
 		if err != nil {
-			log.Warn(err)
+			logger.Warn("Failed to generate ID", "error", err)
 			if err = app.writeError(conn); err != nil {
-				log.Warn("error on write error: %s", err)
+				logger.Warn("error on write error", "error", err)
 				return err
 			}
 			return nil
 		}
-		log.Debugf("Generated ID: %d", id)
+		logger.Debug("Generated ID", "id", id)
 		values[i] = strconv.FormatUint(id, 10)
 	}
 	_, err := MemdValue{

--- a/app.go
+++ b/app.go
@@ -19,7 +19,6 @@ import (
 	"time"
 )
 
-
 // customHandler implements slog.Handler with custom formatting
 type customHandler struct {
 	h slog.Handler
@@ -27,7 +26,7 @@ type customHandler struct {
 
 func newCustomHandler(w io.Writer, level slog.Level) *customHandler {
 	opts := &slog.HandlerOptions{
-		Level: level,
+		Level:     level,
 		AddSource: true,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			// Remove default keys as we'll format them ourselves
@@ -49,15 +48,15 @@ func (h *customHandler) Enabled(ctx context.Context, level slog.Level) bool {
 func (h *customHandler) Handle(ctx context.Context, r slog.Record) error {
 	// Format: 2025-08-01T22:11:28.043+0900    INFO    go-katsubushi/grpc.go:94        Message
 	var buf []byte
-	
+
 	// Time
 	buf = r.Time.AppendFormat(buf, "2006-01-02T15:04:05.000-0700")
 	buf = append(buf, '\t')
-	
+
 	// Level
 	buf = append(buf, r.Level.String()...)
 	buf = append(buf, '\t')
-	
+
 	// Source location
 	if r.PC != 0 {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
@@ -73,10 +72,10 @@ func (h *customHandler) Handle(ctx context.Context, r slog.Record) error {
 		buf = append(buf, strconv.Itoa(f.Line)...)
 		buf = append(buf, '\t')
 	}
-	
+
 	// Message
 	buf = append(buf, r.Message...)
-	
+
 	// Attributes
 	r.Attrs(func(a slog.Attr) bool {
 		buf = append(buf, ' ')
@@ -85,9 +84,9 @@ func (h *customHandler) Handle(ctx context.Context, r slog.Record) error {
 		buf = append(buf, fmt.Sprint(a.Value.Any())...)
 		return true
 	})
-	
+
 	buf = append(buf, '\n')
-	
+
 	_, err := os.Stderr.Write(buf)
 	return err
 }

--- a/app.go
+++ b/app.go
@@ -19,9 +19,6 @@ import (
 	"time"
 )
 
-var (
-	logger *slog.Logger
-)
 
 // customHandler implements slog.Handler with custom formatting
 type customHandler struct {
@@ -167,8 +164,8 @@ func NewAppWithGenerator(gen Generator, workerID uint) (*App, error) {
 
 func init() {
 	handler := newCustomHandler(os.Stderr, slog.LevelInfo)
-	logger = slog.New(handler)
-	slog.SetDefault(logger)
+	l := slog.New(handler)
+	slog.SetDefault(l)
 }
 
 // SetLogLevel sets log level.
@@ -191,14 +188,14 @@ func SetLogLevel(str string) error {
 		return fmt.Errorf("invalid log level %s", str)
 	}
 	handler := newCustomHandler(os.Stderr, level)
-	logger = slog.New(handler)
-	slog.SetDefault(logger)
+	l := slog.New(handler)
+	slog.SetDefault(l)
 	return nil
 }
 
-// StdLogger returns the standard logger.
+// StdLogger returns the standard slog.
 func StdLogger() *stdlog.Logger {
-	return slog.NewLogLogger(logger.Handler(), slog.LevelInfo)
+	return slog.NewLogLogger(slog.Default().Handler(), slog.LevelInfo)
 }
 
 func (app *App) RunServer(ctx context.Context, kc *Config) error {
@@ -240,8 +237,8 @@ func (app *App) ListenerTCP(addr string) (net.Listener, error) {
 
 // Serve starts a server.
 func (app *App) Serve(ctx context.Context, l net.Listener) error {
-	logger.Info("Listening server at " + l.Addr().String())
-	logger.Info("Worker ID = " + strconv.FormatUint(uint64(app.gen.WorkerID()), 10))
+	slog.Info("Listening server at " + l.Addr().String())
+	slog.Info("Worker ID = " + strconv.FormatUint(uint64(app.gen.WorkerID()), 10))
 
 	app.Listener = l
 	close(app.readyCh)
@@ -249,7 +246,7 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 	go func() {
 		<-ctx.Done()
 		if err := l.Close(); err != nil {
-			logger.Warn("Failed to close listener", "error", err)
+			slog.Warn("Failed to close listener", "error", err)
 		}
 	}()
 
@@ -258,14 +255,14 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				logger.Info("Shutting down server")
+				slog.Info("Shutting down server")
 				return nil
 			default:
-				logger.Warn("Error on accept connection", "error", err)
+				slog.Warn("Error on accept connection", "error", err)
 				return err
 			}
 		}
-		logger.Debug("Connected from " + conn.RemoteAddr().String())
+		slog.Debug("Connected from " + conn.RemoteAddr().String())
 
 		go app.handleConn(ctx, conn)
 	}
@@ -282,7 +279,7 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	go func() {
 		<-ctx2.Done()
 		conn.Close()
-		logger.Debug("Closed " + conn.RemoteAddr().String())
+		slog.Debug("Closed " + conn.RemoteAddr().String())
 	}()
 
 	app.extendDeadline(conn)
@@ -291,14 +288,14 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	isBin, err := app.IsBinaryProtocol(bufReader)
 	if err != nil {
 		if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "i/o timeout") {
-			logger.Debug("Connection closed", "remote", conn.RemoteAddr().String(), "error", err)
+			slog.Debug("Connection closed", "remote", conn.RemoteAddr().String(), "error", err)
 			return
 		}
-		logger.Error("error on read first byte to decide binary protocol or not", "error", err)
+		slog.Error("error on read first byte to decide binary protocol or not", "error", err)
 		return
 	}
 	if isBin {
-		logger.Debug("binary protocol")
+		slog.Debug("binary protocol")
 		app.RespondToBinary(bufReader, conn)
 		return
 	}
@@ -309,26 +306,26 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 	for scanner.Scan() {
 		deadline, err = app.extendDeadline(conn)
 		if err != nil {
-			logger.Warn("error on set deadline", "error", err)
+			slog.Warn("error on set deadline", "error", err)
 			return
 		}
 		cmd, err := app.BytesToCmd(scanner.Bytes())
 		if err != nil {
 			if err := app.writeError(conn); err != nil {
-				logger.Warn("error on write error", "error", err)
+				slog.Warn("error on write error", "error", err)
 				return
 			}
 			continue
 		}
 		if err := cmd.Execute(app, w); err != nil {
 			if err != io.EOF {
-				logger.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
+				slog.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
 		if err := w.Flush(); err != nil {
 			if err != io.EOF {
-				logger.Warn("error on cmd write to conn", "cmd", fmt.Sprintf("%v", cmd), "error", err)
+				slog.Warn("error on cmd write to conn", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
@@ -341,9 +338,9 @@ func (app *App) handleConn(ctx context.Context, conn net.Conn) {
 		default:
 		}
 		if !deadline.IsZero() && time.Now().After(deadline) {
-			logger.Debug("deadline exceeded", "error", err)
+			slog.Debug("deadline exceeded", "error", err)
 		} else {
-			logger.Warn("error on scanning request", "error", err)
+			slog.Warn("error on scanning request", "error", err)
 		}
 	}
 }
@@ -367,7 +364,7 @@ func (app *App) GetStats() MemdStats {
 func (app *App) writeError(conn io.Writer) (err error) {
 	_, err = conn.Write(respError)
 	if err != nil {
-		logger.Warn("Failed to write error response", "error", err)
+		slog.Warn("Failed to write error response", "error", err)
 	}
 
 	return
@@ -439,14 +436,14 @@ func (cmd *MemdCmdGet) Execute(app *App, conn io.Writer) error {
 	for i := range cmd.Keys {
 		id, err := app.NextID()
 		if err != nil {
-			logger.Warn("Failed to generate ID", "error", err)
+			slog.Warn("Failed to generate ID", "error", err)
 			if err = app.writeError(conn); err != nil {
-				logger.Warn("error on write error", "error", err)
+				slog.Warn("error on write error", "error", err)
 				return err
 			}
 			return nil
 		}
-		logger.Debug("Generated ID", "id", id)
+		slog.Debug("Generated ID", "id", id)
 		values[i] = strconv.FormatUint(id, 10)
 	}
 	_, err := MemdValue{

--- a/binary_protocol.go
+++ b/binary_protocol.go
@@ -197,7 +197,7 @@ func (app *App) RespondToBinary(r io.Reader, conn net.Conn) {
 		req, err := newBRequest(r)
 		if err != nil {
 			if err != io.EOF {
-				log.Warn(err)
+				logger.Warn("Failed to read binary request", "error", err)
 			}
 			return
 		}
@@ -205,19 +205,19 @@ func (app *App) RespondToBinary(r io.Reader, conn net.Conn) {
 		cmd, err := app.BytesToBinaryCmd(*req)
 		if err != nil {
 			if err := app.writeBinaryError(conn); err != nil {
-				log.Warnf("error on write error: %s", err)
+				logger.Warn("error on write error", "error", err)
 				return
 			}
 			continue
 		}
 		w := bufio.NewWriter(conn)
 		if err := cmd.Execute(app, w); err != nil {
-			log.Warnf("error on execute cmd %s: %s", cmd, err)
+			logger.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			return
 		}
 		if err := w.Flush(); err != nil {
 			if err != io.EOF {
-				log.Warnf("error on cmd %s write: %s", cmd, err)
+				logger.Warn("error on cmd write", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
@@ -276,14 +276,14 @@ type MemdBCmdGet struct {
 func (cmd *MemdBCmdGet) Execute(app *App, w io.Writer) error {
 	id, err := app.NextID()
 	if err != nil {
-		log.Warn(err)
+		logger.Warn("Failed to generate ID", "error", err)
 		if err = app.writeError(w); err != nil {
-			log.Warn("error on write error: %s", err)
+			logger.Warn("error on write error", "error", err)
 			return err
 		}
 		return nil
 	}
-	log.Debugf("Generated ID: %d", id)
+	logger.Debug("Generated ID", "id", id)
 
 	res := newBResponse(opcodeGet, cmd.Opaque, bResponseConfig{
 		// fixed 4bytes flags is given to GET response

--- a/binary_protocol.go
+++ b/binary_protocol.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"reflect"
 	"strconv"
@@ -197,7 +198,7 @@ func (app *App) RespondToBinary(r io.Reader, conn net.Conn) {
 		req, err := newBRequest(r)
 		if err != nil {
 			if err != io.EOF {
-				logger.Warn("Failed to read binary request", "error", err)
+				slog.Warn("Failed to read binary request", "error", err)
 			}
 			return
 		}
@@ -205,19 +206,19 @@ func (app *App) RespondToBinary(r io.Reader, conn net.Conn) {
 		cmd, err := app.BytesToBinaryCmd(*req)
 		if err != nil {
 			if err := app.writeBinaryError(conn); err != nil {
-				logger.Warn("error on write error", "error", err)
+				slog.Warn("error on write error", "error", err)
 				return
 			}
 			continue
 		}
 		w := bufio.NewWriter(conn)
 		if err := cmd.Execute(app, w); err != nil {
-			logger.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
+			slog.Warn("error on execute cmd", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			return
 		}
 		if err := w.Flush(); err != nil {
 			if err != io.EOF {
-				logger.Warn("error on cmd write", "cmd", fmt.Sprintf("%v", cmd), "error", err)
+				slog.Warn("error on cmd write", "cmd", fmt.Sprintf("%v", cmd), "error", err)
 			}
 			return
 		}
@@ -276,14 +277,14 @@ type MemdBCmdGet struct {
 func (cmd *MemdBCmdGet) Execute(app *App, w io.Writer) error {
 	id, err := app.NextID()
 	if err != nil {
-		logger.Warn("Failed to generate ID", "error", err)
+		slog.Warn("Failed to generate ID", "error", err)
 		if err = app.writeError(w); err != nil {
-			logger.Warn("error on write error", "error", err)
+			slog.Warn("error on write error", "error", err)
 			return err
 		}
 		return nil
 	}
-	logger.Debug("Generated ID", "id", id)
+	slog.Debug("Generated ID", "id", id)
 
 	res := newBResponse(opcodeGet, cmd.Opaque, bResponseConfig{
 		// fixed 4bytes flags is given to GET response

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/fukata/golang-stats-api-handler v1.0.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/pkg/errors v0.9.1
-	go.uber.org/zap v1.10.0
 	google.golang.org/grpc v1.73.0
 	google.golang.org/protobuf v1.36.6
 )
@@ -23,8 +22,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	go.uber.org/atomic v1.4.0 // indirect
-	go.uber.org/multierr v1.1.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,11 +102,8 @@ go.opentelemetry.io/otel/sdk/metric v1.35.0 h1:1RriWBmCKgkeHEhM7a2uMjMUfP7MsOF5J
 go.opentelemetry.io/otel/sdk/metric v1.35.0/go.mod h1:is6XYCUMpcKi+ZsOvfluY5YstFnhW0BidkR+gL+qN+w=
 go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
-go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/grpc.go
+++ b/grpc.go
@@ -3,6 +3,7 @@ package katsubushi
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"sync/atomic"
 
@@ -28,13 +29,13 @@ type gRPCGenerator struct {
 
 func (sv *gRPCGenerator) Fetch(ctx context.Context, req *grpc.FetchRequest) (*grpc.FetchResponse, error) {
 	atomic.AddInt64(&sv.app.cmdGet, 1)
-	logger.Debug("gRPC Fetch request")
+	slog.Debug("gRPC Fetch request")
 
 	id, err := sv.app.NextID()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get id")
 	}
-	logger.Debug("gRPC Generated ID", "id", id)
+	slog.Debug("gRPC Generated ID", "id", id)
 	res := &grpc.FetchResponse{
 		Id: id,
 	}
@@ -44,7 +45,7 @@ func (sv *gRPCGenerator) Fetch(ctx context.Context, req *grpc.FetchRequest) (*gr
 func (sv *gRPCGenerator) FetchMulti(ctx context.Context, req *grpc.FetchMultiRequest) (*grpc.FetchMultiResponse, error) {
 	atomic.AddInt64(&sv.app.cmdGet, 1)
 	n := int(req.N)
-	logger.Debug("gRPC FetchMulti request", "n", n)
+	slog.Debug("gRPC FetchMulti request", "n", n)
 	if n > MaxGRPCBulkSize {
 		return nil, errors.Errorf("too many IDs requested: %d, n should be smaller than %d", n, MaxGRPCBulkSize)
 	}
@@ -59,7 +60,7 @@ func (sv *gRPCGenerator) FetchMulti(ctx context.Context, req *grpc.FetchMultiReq
 		}
 		ids = append(ids, id)
 	}
-	logger.Debug("gRPC Generated IDs", "ids", ids)
+	slog.Debug("gRPC Generated IDs", "ids", ids)
 	res := &grpc.FetchMultiResponse{
 		Ids: ids,
 	}
@@ -91,16 +92,16 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	listener = app.wrapListener(listener)
 	go func() {
 		<-ctx.Done()
-		logger.Info("Shutting down gRPC server")
+		slog.Info("Shutting down gRPC server")
 		s.Stop()
 	}()
 
-	logger.Info("Listening gRPC server at " + listener.Addr().String())
+	slog.Info("Listening gRPC server at " + listener.Addr().String())
 	return s.Serve(listener)
 }
 
 func grpcRecoveryFunc(p interface{}) error {
-	logger.Error("panic", "value", p)
+	slog.Error("panic", "value", p)
 	return status.Errorf(codes.Internal, "Unexpected error")
 }
 
@@ -110,7 +111,7 @@ type gRPCStats struct {
 }
 
 func (sv *gRPCStats) Get(ctx context.Context, req *grpc.StatsRequest) (*grpc.StatsResponse, error) {
-	logger.Debug("gRPC Stats request")
+	slog.Debug("gRPC Stats request")
 	st := sv.app.GetStats()
 	return &grpc.StatsResponse{
 		Pid:              int32(st.Pid),

--- a/grpc.go
+++ b/grpc.go
@@ -28,11 +28,13 @@ type gRPCGenerator struct {
 
 func (sv *gRPCGenerator) Fetch(ctx context.Context, req *grpc.FetchRequest) (*grpc.FetchResponse, error) {
 	atomic.AddInt64(&sv.app.cmdGet, 1)
+	logger.Debug("gRPC Fetch request")
 
 	id, err := sv.app.NextID()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get id")
 	}
+	logger.Debug("gRPC Generated ID", "id", id)
 	res := &grpc.FetchResponse{
 		Id: id,
 	}
@@ -42,6 +44,7 @@ func (sv *gRPCGenerator) Fetch(ctx context.Context, req *grpc.FetchRequest) (*gr
 func (sv *gRPCGenerator) FetchMulti(ctx context.Context, req *grpc.FetchMultiRequest) (*grpc.FetchMultiResponse, error) {
 	atomic.AddInt64(&sv.app.cmdGet, 1)
 	n := int(req.N)
+	logger.Debug("gRPC FetchMulti request", "n", n)
 	if n > MaxGRPCBulkSize {
 		return nil, errors.Errorf("too many IDs requested: %d, n should be smaller than %d", n, MaxGRPCBulkSize)
 	}
@@ -56,6 +59,7 @@ func (sv *gRPCGenerator) FetchMulti(ctx context.Context, req *grpc.FetchMultiReq
 		}
 		ids = append(ids, id)
 	}
+	logger.Debug("gRPC Generated IDs", "ids", ids)
 	res := &grpc.FetchMultiResponse{
 		Ids: ids,
 	}
@@ -87,16 +91,16 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	listener = app.wrapListener(listener)
 	go func() {
 		<-ctx.Done()
-		log.Infof("Shutting down gRPC server")
+		logger.Info("Shutting down gRPC server")
 		s.Stop()
 	}()
 
-	log.Infof("Listening gRPC server at %s", listener.Addr())
+	logger.Info("Listening gRPC server at " + listener.Addr().String())
 	return s.Serve(listener)
 }
 
 func grpcRecoveryFunc(p interface{}) error {
-	log.Errorf("panic: %v", p)
+	logger.Error("panic", "value", p)
 	return status.Errorf(codes.Internal, "Unexpected error")
 }
 
@@ -106,6 +110,7 @@ type gRPCStats struct {
 }
 
 func (sv *gRPCStats) Get(ctx context.Context, req *grpc.StatsRequest) (*grpc.StatsResponse, error) {
+	logger.Debug("gRPC Stats request")
 	st := sv.app.GetStats()
 	return &grpc.StatsResponse{
 		Pid:              int32(st.Pid),

--- a/http.go
+++ b/http.go
@@ -33,7 +33,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 	// shutdown
 	go func() {
 		<-ctx.Done()
-		log.Infof("Shutting down HTTP server")
+		logger.Info("Shutting down HTTP server")
 		s.Shutdown(ctx)
 	}()
 
@@ -46,7 +46,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 		}
 	}
 	listener = app.wrapListener(listener)
-	log.Infof("Listening HTTP server at %s", listener.Addr())
+	logger.Info("Listening HTTP server at " + listener.Addr().String())
 	return s.Serve(listener)
 }
 
@@ -56,13 +56,14 @@ func (app *App) HTTPGetSingleID(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	atomic.AddInt64(&app.cmdGet, 1)
+	logger.Debug("HTTP GetSingleID request", "remote", req.RemoteAddr)
 	id, err := app.NextID()
 	if err != nil {
-		log.Error(err)
+		logger.Error("Failed to generate ID", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	log.Debugf("Generated ID: %d", id)
+	logger.Debug("HTTP Generated ID", "id", id)
 	if strings.Contains(req.Header.Get("Accept"), "application/json") {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"id":"%d"}`, id)
@@ -78,6 +79,7 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	atomic.AddInt64(&app.cmdGet, 1)
+	logger.Debug("HTTP GetMultiID request", "remote", req.RemoteAddr)
 	var n int64
 	if ns := req.FormValue("n"); ns == "" {
 		n = 1
@@ -85,14 +87,14 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 		var err error
 		n, err = strconv.ParseInt(ns, 10, 64)
 		if err != nil {
-			log.Error(err)
+			logger.Error("Failed to parse n parameter", "error", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 	}
 	if n > MaxHTTPBulkSize {
 		msg := fmt.Sprintf("too many IDs requested: %d, n should be smaller than %d", n, MaxHTTPBulkSize)
-		log.Error(msg)
+		logger.Error(msg)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(msg))
 		return
@@ -101,13 +103,13 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 	for i := int64(0); i < n; i++ {
 		id, err := app.NextID()
 		if err != nil {
-			log.Error(err)
+			logger.Error("Failed to generate ID", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		ids = append(ids, strconv.FormatUint(id, 10))
 	}
-	log.Debugf("Generated IDs: %v", ids)
+	logger.Debug("HTTP Generated IDs", "ids", ids, "count", len(ids))
 	if strings.Contains(req.Header.Get("Accept"), "application/json") {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(struct {
@@ -124,12 +126,13 @@ func (app *App) HTTPGetStats(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
+	logger.Debug("HTTP GetStats request", "remote", req.RemoteAddr)
 	s := app.GetStats()
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(s); err != nil {
-		log.Error(err)
+		logger.Error("Failed to encode stats", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/http.go
+++ b/http.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,7 +34,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 	// shutdown
 	go func() {
 		<-ctx.Done()
-		logger.Info("Shutting down HTTP server")
+		slog.Info("Shutting down HTTP server")
 		s.Shutdown(ctx)
 	}()
 
@@ -46,7 +47,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 		}
 	}
 	listener = app.wrapListener(listener)
-	logger.Info("Listening HTTP server at " + listener.Addr().String())
+	slog.Info("Listening HTTP server at " + listener.Addr().String())
 	return s.Serve(listener)
 }
 
@@ -56,14 +57,14 @@ func (app *App) HTTPGetSingleID(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	atomic.AddInt64(&app.cmdGet, 1)
-	logger.Debug("HTTP GetSingleID request", "remote", req.RemoteAddr)
+	slog.Debug("HTTP GetSingleID request", "remote", req.RemoteAddr)
 	id, err := app.NextID()
 	if err != nil {
-		logger.Error("Failed to generate ID", "error", err)
+		slog.Error("Failed to generate ID", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	logger.Debug("HTTP Generated ID", "id", id)
+	slog.Debug("HTTP Generated ID", "id", id)
 	if strings.Contains(req.Header.Get("Accept"), "application/json") {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"id":"%d"}`, id)
@@ -79,7 +80,7 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	atomic.AddInt64(&app.cmdGet, 1)
-	logger.Debug("HTTP GetMultiID request", "remote", req.RemoteAddr)
+	slog.Debug("HTTP GetMultiID request", "remote", req.RemoteAddr)
 	var n int64
 	if ns := req.FormValue("n"); ns == "" {
 		n = 1
@@ -87,14 +88,14 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 		var err error
 		n, err = strconv.ParseInt(ns, 10, 64)
 		if err != nil {
-			logger.Error("Failed to parse n parameter", "error", err)
+			slog.Error("Failed to parse n parameter", "error", err)
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 	}
 	if n > MaxHTTPBulkSize {
 		msg := fmt.Sprintf("too many IDs requested: %d, n should be smaller than %d", n, MaxHTTPBulkSize)
-		logger.Error(msg)
+		slog.Error(msg)
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(msg))
 		return
@@ -103,13 +104,13 @@ func (app *App) HTTPGetMultiID(w http.ResponseWriter, req *http.Request) {
 	for i := int64(0); i < n; i++ {
 		id, err := app.NextID()
 		if err != nil {
-			logger.Error("Failed to generate ID", "error", err)
+			slog.Error("Failed to generate ID", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		ids = append(ids, strconv.FormatUint(id, 10))
 	}
-	logger.Debug("HTTP Generated IDs", "ids", ids, "count", len(ids))
+	slog.Debug("HTTP Generated IDs", "ids", ids, "count", len(ids))
 	if strings.Contains(req.Header.Get("Accept"), "application/json") {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(struct {
@@ -126,13 +127,13 @@ func (app *App) HTTPGetStats(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	logger.Debug("HTTP GetStats request", "remote", req.RemoteAddr)
+	slog.Debug("HTTP GetStats request", "remote", req.RemoteAddr)
 	s := app.GetStats()
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(s); err != nil {
-		logger.Error("Failed to encode stats", "error", err)
+		slog.Error("Failed to encode stats", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary
- Replace go.uber.org/zap with log/slog
- Implement custom handler to maintain original log format (timestamp, level, source, message)
- Add debug logging for all protocols (memcached, gRPC, HTTP API)
- Remove zap dependency from go.mod

## Changes
- **app.go**: Implement custom slog handler with original format and replace all zap calls
- **grpc.go**: Replace zap with slog and add debug logs for gRPC endpoints
- **http.go**: Replace zap with slog and add debug logs for HTTP API endpoints  
- **binary_protocol.go**: Replace zap with slog for binary protocol
- **go.mod/go.sum**: Remove zap dependency

## Test plan
- [x] Build succeeds
- [x] Server starts with all protocols (memcached, gRPC, HTTP)
- [x] Log format matches original: `2025-08-01T22:11:28.043+0900    INFO    go-katsubushi/app.go:166    Message`
- [x] Debug logs work with `-log-level debug` for all protocols
- [x] All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)