### PR TITLE
Update Alpine Linux base image to 3.22

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # katsubushi
 
-FROM alpine:3.16.2
+FROM alpine:3.22
 ARG VERSION
 ARG TARGETARCH
 ADD dist/go-katsubushi_linux_${TARGETARCH}*/katsubushi /usr/local/bin/katsubushi


### PR DESCRIPTION
Update Docker base image from Alpine 3.16.2 to 3.22 (latest stable version).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>