### PR TITLE
Add gRPC health check endpoint

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -13,6 +13,8 @@ import (
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	gogrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 )
@@ -78,6 +80,16 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	))
 	grpc.RegisterGeneratorServer(s, svGen)
 	grpc.RegisterStatsServer(s, svStats)
+	
+	// Register health check service
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(s, healthServer)
+	
+	// Set health status for overall server and individual services
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(grpc.Generator_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(grpc.Stats_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	
 	reflection.Register(s)
 
 	listener := cfg.GRPCListener


### PR DESCRIPTION
Add standard gRPC health check endpoint using google.golang.org/grpc/health for Kubernetes liveness/readiness probes support.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>