### PR TITLE
Modernize syntax with gopls modernize analyzer

### DIFF
--- a/app.go
+++ b/app.go
@@ -170,7 +170,7 @@ type App struct {
 	Listener net.Listener
 
 	gen     Generator
-	readyCh chan interface{}
+	readyCh chan any
 
 	// App will disconnect connection if there are no commands until idleTimeout.
 	idleTimeout time.Duration
@@ -178,8 +178,8 @@ type App struct {
 	startedAt time.Time
 
 	// these values are accessed atomically
-	currConnections  int64
-	totalConnections int64
+	currConnections  atomic.Int64
+	totalConnections atomic.Int64
 	cmdGet           int64
 	getHits          int64
 	getMisses        int64
@@ -194,7 +194,7 @@ func New(workerID uint) (*App, error) {
 	return &App{
 		gen:       gen,
 		startedAt: time.Now(),
-		readyCh:   make(chan interface{}),
+		readyCh:   make(chan any),
 	}, nil
 }
 
@@ -203,7 +203,7 @@ func NewAppWithGenerator(gen Generator, workerID uint) (*App, error) {
 	return &App{
 		gen:       gen,
 		startedAt: time.Now(),
-		readyCh:   make(chan interface{}),
+		readyCh:   make(chan any),
 	}, nil
 }
 
@@ -314,7 +314,7 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 }
 
 // Ready returns a channel which become readable when the app can accept connections.
-func (app *App) Ready() chan interface{} {
+func (app *App) Ready() chan any {
 	return app.readyCh
 }
 
@@ -398,8 +398,8 @@ func (app *App) GetStats() MemdStats {
 		Uptime:           int64(now.Sub(app.startedAt).Seconds()),
 		Time:             time.Now().Unix(),
 		Version:          Version,
-		CurrConnections:  atomic.LoadInt64(&app.currConnections),
-		TotalConnections: atomic.LoadInt64(&app.totalConnections),
+		CurrConnections:  app.currConnections.Load(),
+		TotalConnections: app.totalConnections.Load(),
 		CmdGet:           atomic.LoadInt64(&app.cmdGet),
 		GetHits:          atomic.LoadInt64(&app.getHits),
 		GetMisses:        atomic.LoadInt64(&app.getMisses),
@@ -568,7 +568,7 @@ func (v MemdValue) WriteTo(w io.Writer) (int64, error) {
 // WriteTo writes result of STATS command to io.Writer.
 func (s MemdStats) WriteTo(w io.Writer) (int64, error) {
 	statsValue := reflect.ValueOf(s)
-	statsType := reflect.TypeOf(s)
+	statsType := reflect.TypeFor[MemdStats]()
 	for i := 0; i < statsType.NumField(); i++ {
 		w.Write(memdStatHeader)
 		field := statsType.Field(i)

--- a/binary_protocol.go
+++ b/binary_protocol.go
@@ -327,7 +327,7 @@ func (cmd *MemdBCmdStat) Execute(app *App, w io.Writer) error {
 
 func (s MemdStats) writeBinaryTo(w io.Writer, opaque [4]byte) error {
 	statsValue := reflect.ValueOf(s)
-	statsType := reflect.TypeOf(s)
+	statsType := reflect.TypeFor[MemdStats]()
 	for i := 0; i < statsType.NumField(); i++ {
 		field := statsType.Field(i)
 		tag := field.Tag.Get("memd")

--- a/client.go
+++ b/client.go
@@ -59,7 +59,7 @@ func (c *Client) Fetch(ctx context.Context) (uint64, error) {
 func (c *Client) FetchMulti(ctx context.Context, n int) ([]uint64, error) {
 	keys := make([]string, 0, n)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		keys = append(keys, strconv.Itoa(i))
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func BenchmarkClientFetch(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 	app := newTestAppAndListenTCP(ctx, b, nil)
 
 	b.ResetTimer()
@@ -30,8 +29,7 @@ func BenchmarkClientFetch(b *testing.B) {
 }
 
 func BenchmarkGoMemcacheFetch(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 	app := newTestAppAndListenTCP(ctx, b, nil)
 
 	b.ResetTimer()
@@ -48,8 +46,7 @@ func BenchmarkGoMemcacheFetch(b *testing.B) {
 }
 
 func TestClientFetch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
@@ -64,8 +61,7 @@ func TestClientFetch(t *testing.T) {
 }
 
 func TestClientMulti(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	app := newTestAppAndListenTCP(ctx, t, nil)
 	c := NewClient(app.Listener.Addr().String())
 
@@ -85,14 +81,13 @@ func TestClientMulti(t *testing.T) {
 }
 
 func TestClientFetchRetry(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	to := time.Second
 	app := newTestAppAndListenTCP(ctx, t, &to)
 
 	c := NewClient(app.Listener.Addr().String())
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		id, err := c.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -110,8 +105,7 @@ func TestClientFetchBackup(t *testing.T) {
 	defer cancel1()
 	app1 := newTestAppAndListenTCP(ctx1, t, nil)
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 	app2 := newTestAppAndListenTCP(ctx2, t, nil)
 
 	c := NewClient(
@@ -224,8 +218,7 @@ func TestClientFailBackupMulti(t *testing.T) {
 }
 
 func TestClientTimeout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	app := newTestAppDelayed(t, time.Second)
 	l, _ := app.ListenerTCP("localhost:0")

--- a/generator.go
+++ b/generator.go
@@ -2,6 +2,7 @@ package katsubushi
 
 import (
 	"errors"
+	"slices"
 	"sync"
 	"time"
 )
@@ -47,10 +48,8 @@ func checkWorkerID(id uint) error {
 		return ErrInvalidWorkerID
 	}
 
-	for _, otherID := range workerIDPool {
-		if id == otherID {
-			return ErrDuplicatedWorkerID
-		}
+	if slices.Contains(workerIDPool, id) {
+		return ErrDuplicatedWorkerID
 	}
 
 	return nil

--- a/generator_test.go
+++ b/generator_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 )
 
-var nextWorkerID uint32
+var nextWorkerID atomic.Uint32
 
 func getNextWorkerID() uint {
-	return uint(atomic.AddUint32(&nextWorkerID, 1))
+	return uint(nextWorkerID.Add(1))
 }
 
 func TestInvalidWorkerID(t *testing.T) {
@@ -94,7 +94,7 @@ func TestGenerateSomeIDs(t *testing.T) {
 	g, _ := NewGenerator(getNextWorkerID())
 	ids := []uint64{}
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		id, err := g.NextID()
 		if err != nil {
 			t.Fatalf("failed to generate id: %s", err)

--- a/grpc.go
+++ b/grpc.go
@@ -80,16 +80,16 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	))
 	grpc.RegisterGeneratorServer(s, svGen)
 	grpc.RegisterStatsServer(s, svStats)
-	
+
 	// Register health check service
 	healthServer := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(s, healthServer)
-	
+
 	// Set health status for overall server and individual services
 	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	healthServer.SetServingStatus(grpc.Generator_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
 	healthServer.SetServingStatus(grpc.Stats_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
-	
+
 	reflection.Register(s)
 
 	listener := cfg.GRPCListener
@@ -111,7 +111,7 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	return s.Serve(listener)
 }
 
-func grpcRecoveryFunc(p interface{}) error {
+func grpcRecoveryFunc(p any) error {
 	slog.Error("panic", "value", p)
 	return status.Errorf(codes.Internal, "Unexpected error")
 }

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -52,7 +52,7 @@ func TestGRPCSingle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		res, err := client.Fetch(context.Background(), &grpc.FetchRequest{})
 		if err != nil {
 			t.Fatal(err)
@@ -70,7 +70,7 @@ func TestGRPCMulti(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		res, err := client.FetchMulti(context.Background(), &grpc.FetchMultiRequest{N: 10})
 		if err != nil {
 			t.Fatal(err)

--- a/http.go
+++ b/http.go
@@ -151,7 +151,7 @@ func NewHTTPClient(urls []string, pathPrefix string) (*HTTPClient, error) {
 			Timeout: DefaultClientTimeout,
 		},
 		pool: &sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return new(bytes.Buffer)
 			},
 		},

--- a/http_test.go
+++ b/http_test.go
@@ -170,7 +170,7 @@ func TestHTTPSingleCS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		id, err := client.Fetch(context.Background())
 		if err != nil {
 			t.Fatal(err)
@@ -188,7 +188,7 @@ func TestHTTPMultiCS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ids, err := client.FetchMulti(context.Background(), 10)
 		if err != nil {
 			t.Fatal(err)

--- a/listener.go
+++ b/listener.go
@@ -3,7 +3,6 @@ package katsubushi
 import (
 	"net"
 	"sync"
-	"sync/atomic"
 )
 
 func (app *App) wrapListener(l net.Listener) net.Listener {
@@ -27,8 +26,8 @@ func (l *monitListener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	atomic.AddInt64(&l.app.currConnections, 1)
-	atomic.AddInt64(&l.app.totalConnections, 1)
+	l.app.currConnections.Add(1)
+	l.app.totalConnections.Add(1)
 	return &monitConn{conn, l.app, &sync.Once{}}, nil
 }
 
@@ -40,7 +39,7 @@ type monitConn struct {
 
 func (c *monitConn) Close() error {
 	c.once.Do(func() {
-		atomic.AddInt64(&c.app.currConnections, -1)
+		c.app.currConnections.Add(-1)
 	})
 	return c.Conn.Close()
 }

--- a/memcache.go
+++ b/memcache.go
@@ -107,7 +107,7 @@ func (c *memcacheClient) GetMulti(ctx context.Context, keys []string) ([]uint64,
 	}
 
 	ids := make([]uint64, 0, len(keys))
-	for i := 0; i < len(keys); i++ {
+	for range keys {
 		id, err := readValue(c.rw.Reader)
 		if err != nil {
 			c.close()


### PR DESCRIPTION
## What

Modernize Go syntax using the `gopls` modernize analyzer:

- `interface{}` → `any`
- atomic int fields → `atomic.Int64` / `atomic.Uint32`
- manual loop → `slices.Contains`
- `reflect.TypeOf` → `reflect.TypeFor`
- `for i := 0; i < n; i++` → `for range n`
- `context.WithCancel` in tests → `t.Context()` / `b.Context()`

Generated `*.pb.go` files are left untouched.

## Why

Keep the codebase aligned with current Go idioms.