### PR TITLE
Fix HTTP client failover across multiple servers

### DIFF
--- a/http.go
+++ b/http.go
@@ -205,6 +205,7 @@ func (c *HTTPClient) Fetch(ctx context.Context) (uint64, error) {
 		}(u)
 		if err != nil {
 			errs = fmt.Errorf("failed to fetch id from %s: %w", u, err)
+			continue
 		}
 		return id, nil
 	}
@@ -214,7 +215,6 @@ func (c *HTTPClient) Fetch(ctx context.Context) (uint64, error) {
 // FetchMulti fetches multiple ids from katsubushi via HTTP
 func (c *HTTPClient) FetchMulti(ctx context.Context, n int) ([]uint64, error) {
 	errs := fmt.Errorf("no servers available")
-	ids := make([]uint64, 0, n)
 	for _, u := range c.urls {
 		ids, err := func(u *url.URL) ([]uint64, error) {
 			u.Path = fmt.Sprintf("/%sids", c.pathPrefix)
@@ -236,23 +236,24 @@ func (c *HTTPClient) FetchMulti(ctx context.Context, n int) ([]uint64, error) {
 			}()
 			if _, err := io.Copy(b, resp.Body); err != nil {
 				return nil, err
-
 			}
 			bs := bytes.Split(b.Bytes(), []byte("\n"))
 			if len(bs) != n {
-				return nil, err
+				return nil, fmt.Errorf("unexpected number of ids: got %d, want %d", len(bs), n)
 			}
+			ids := make([]uint64, 0, n)
 			for _, b := range bs {
-				if id, err := strconv.ParseUint(string(b), 10, 64); err != nil {
+				id, err := strconv.ParseUint(string(b), 10, 64)
+				if err != nil {
 					return nil, err
-				} else {
-					ids = append(ids, id)
 				}
+				ids = append(ids, id)
 			}
 			return ids, nil
 		}(u)
 		if err != nil {
-			errs = fmt.Errorf("failed to fetch ids from %s: %w", u, errs)
+			errs = fmt.Errorf("failed to fetch ids from %s: %w", u, err)
+			continue
 		}
 		return ids, nil
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
@@ -202,6 +203,56 @@ func TestHTTPMultiCS(t *testing.T) {
 			}
 		}
 		t.Logf("HTTP fetched IDs: %v", ids)
+	}
+}
+
+func TestHTTPFailover(t *testing.T) {
+	// The first server always fails; the client must fail over to the healthy one.
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	good := fmt.Sprintf("http://localhost:%d", httpPort)
+
+	client, err := katsubushi.NewHTTPClient([]string{bad.URL, good}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id, err := client.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch should fail over to the healthy server: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("id should not be 0")
+	}
+
+	ids, err := client.FetchMulti(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("FetchMulti should fail over to the healthy server: %v", err)
+	}
+	if len(ids) != 10 {
+		t.Fatalf("ids should contain 10 elements: %v", ids)
+	}
+}
+
+func TestHTTPAllServersFail(t *testing.T) {
+	// When every server fails, an error must be returned (not a zero value).
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+
+	client, err := katsubushi.NewHTTPClient([]string{bad.URL}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id, err := client.Fetch(context.Background()); err == nil {
+		t.Fatalf("Fetch should return an error when all servers fail, got id=%d", id)
+	}
+	if ids, err := client.FetchMulti(context.Background(), 10); err == nil {
+		t.Fatalf("FetchMulti should return an error when all servers fail, got ids=%v", ids)
 	}
 }
 


### PR DESCRIPTION
## What

`Fetch` and `FetchMulti` had a `for _, u := range c.urls` loop that was meant to fail over across multiple katsubushi servers, but the loop body returned unconditionally on the first iteration:

- Only the first server was ever tried (failover never happened).
- When the first server failed, the methods returned a zero value with a `nil` error, silently swallowing the failure.

Now they continue to the next server on error and return the accumulated error only when all servers fail.

`FetchMulti` additionally:
- builds its result slice per attempt (it previously appended to a slice shared across attempts),
- wraps the actual per-server error (it previously wrapped `errs` into itself),
- returns an error on an unexpected id count (it previously returned `nil, nil`).

## Test

Added `TestHTTPFailover` (first server 500s, client must fall back to a healthy one) and `TestHTTPAllServersFail` (all servers fail → error must be returned).