### PR TITLE
Run CI once per PR instead of on both push and pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Go
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v2
+  pull_request:
 jobs:
   test:
     strategy:


### PR DESCRIPTION
## What

Change the `Go` workflow trigger from `on: [push, pull_request]` to push on the `main`/`v2` branches plus `pull_request`.

## Why

With `[push, pull_request]`, a PR from a same-repo branch runs the workflow twice — once for the branch `push` and once for the `pull_request`. Scoping `push` to the main/v2 branches makes PRs run only via the `pull_request` event, while pushes to the default branch (merges) still run CI.