### PR TITLE
Improve startup configuration and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,16 @@ Note:
 
 `-worker-id` or `-redis` is required.
 
+All options can also be set via environment variables. For each option, the following environment variables are looked up in order, and the first one found is used. For example, for `-worker-id`:
+
+1. `KATSUBUSHI_WORKER_ID`
+2. `WORKER_ID`
+3. `worker_id`
+
+Commandline options take precedence over environment variables.
+
+The `KATSUBUSHI_` prefixed form is recommended because non-prefixed names may conflict with unrelated environment variables (e.g. `PORT` or `VERSION` are commonly set by platforms).
+
 ### -worker-id
 
 ID of the worker, must be unique in your service.

--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ If we use multi katsubushi clusters, worker-id range for each clusters must not 
 ### -port
 
 Optional.
-Port number used for connection.
+Port number of the memcached compatible server.
 Default value is `11212`.
+`0` means disable (e.g. to serve the HTTP or gRPC server only).
+At least one of `-port`, `-sock`, `-http-port` or `-grpc-port` must be enabled.
 
 ### -sock
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Default value is `600`.
 Optional.
 Default value is `info`.
 
+### -log-format
+
+Optional.
+Log format, `text` or `json`.
+Default value is `text`.
+
 ### -enable-pprof
 
 Optional.

--- a/app.go
+++ b/app.go
@@ -224,10 +224,27 @@ func newApp(gen Generator) *App {
 	}
 }
 
+var (
+	logLevel  = slog.LevelInfo
+	logFormat = "text"
+)
+
 func init() {
-	handler := newCustomHandler(os.Stderr, slog.LevelInfo)
-	l := slog.New(handler)
-	slog.SetDefault(l)
+	setDefaultLogger()
+}
+
+func newLogHandler(w io.Writer, level slog.Level, format string) slog.Handler {
+	if format == "json" {
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level:     level,
+			AddSource: true,
+		})
+	}
+	return newCustomHandler(w, level)
+}
+
+func setDefaultLogger() {
+	slog.SetDefault(slog.New(newLogHandler(os.Stderr, logLevel, logFormat)))
 }
 
 // SetLogLevel sets log level.
@@ -249,9 +266,23 @@ func SetLogLevel(str string) error {
 	default:
 		return fmt.Errorf("invalid log level %s", str)
 	}
-	handler := newCustomHandler(os.Stderr, level)
-	l := slog.New(handler)
-	slog.SetDefault(l)
+	logLevel = level
+	setDefaultLogger()
+	return nil
+}
+
+// SetLogFormat sets log format.
+// Log format must be one of text and json.
+func SetLogFormat(format string) error {
+	switch format {
+	case "", "text":
+		format = "text"
+	case "json":
+	default:
+		return fmt.Errorf("invalid log format %s", format)
+	}
+	logFormat = format
+	setDefaultLogger()
 	return nil
 }
 

--- a/app.go
+++ b/app.go
@@ -299,9 +299,11 @@ func (app *App) ListenerTCP(addr string) (net.Listener, error) {
 
 // Serve starts a server.
 func (app *App) Serve(ctx context.Context, l net.Listener) error {
-	slog.Info("Listening server at " + l.Addr().String())
-	slog.Info("Worker ID = " + strconv.FormatUint(uint64(app.gen.WorkerID()), 10))
-	slog.Info("ID format = " + app.idFormat)
+	slog.Info("Listening server",
+		"addr", l.Addr().String(),
+		"worker_id", uint64(app.gen.WorkerID()),
+		"id_format", app.idFormat,
+	)
 
 	app.Listener = l
 	close(app.readyCh)

--- a/app_log_test.go
+++ b/app_log_test.go
@@ -1,0 +1,66 @@
+package katsubushi
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLogHandlerText(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(newLogHandler(&buf, slog.LevelInfo, "text"))
+	logger.Info("hello", "worker_id", uint64(5))
+
+	line := buf.String()
+	if !strings.Contains(line, "hello") {
+		t.Errorf("message not found in log: %s", line)
+	}
+	if !strings.Contains(line, "worker_id=5") {
+		t.Errorf("attribute not found in log: %s", line)
+	}
+	if !strings.Contains(line, "INFO") {
+		t.Errorf("level not found in log: %s", line)
+	}
+}
+
+func TestLogHandlerJSON(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(newLogHandler(&buf, slog.LevelInfo, "json"))
+	logger.Info("hello", "worker_id", uint64(5))
+
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("failed to parse log as JSON: %s: %s", err, buf.String())
+	}
+	if m["msg"] != "hello" {
+		t.Errorf("unexpected msg: %v", m["msg"])
+	}
+	if m["level"] != "INFO" {
+		t.Errorf("unexpected level: %v", m["level"])
+	}
+	if m["worker_id"] != float64(5) {
+		t.Errorf("unexpected worker_id: %v", m["worker_id"])
+	}
+	if m["source"] == nil {
+		t.Errorf("source not found in log: %s", buf.String())
+	}
+}
+
+func TestLogHandlerLevel(t *testing.T) {
+	for _, format := range []string{"text", "json"} {
+		var buf bytes.Buffer
+		logger := slog.New(newLogHandler(&buf, slog.LevelInfo, format))
+		logger.Debug("hidden")
+		if buf.Len() != 0 {
+			t.Errorf("debug log must be suppressed at info level (%s): %s", format, buf.String())
+		}
+	}
+}
+
+func TestSetLogFormatInvalid(t *testing.T) {
+	if err := SetLogFormat("xml"); err == nil {
+		t.Error("SetLogFormat must return an error for an invalid format")
+	}
+}

--- a/cmd/katsubushi/main.go
+++ b/cmd/katsubushi/main.go
@@ -48,7 +48,7 @@ func main() {
 	kc := &katsubushi.Config{}
 
 	flag.UintVar(&workerID, "worker-id", 0, "worker id. must be unique.")
-	flag.IntVar(&kc.Port, "port", 11212, "port to listen.")
+	flag.IntVar(&kc.Port, "port", 11212, "port to listen. 0 means disable.")
 	flag.StringVar(&kc.Sockpath, "sock", "", "unix domain socket to listen. ignore port option when set this.")
 	flag.DurationVar(&kc.IdleTimeout, "idle-timeout", katsubushi.DefaultIdleTimeout, "connection will be closed if there are no packets over the seconds. 0 means infinite.")
 	flag.StringVar(&kc.LogLevel, "log-level", "info", "log level (panic, fatal, error, warn, info = Default, debug)")
@@ -74,6 +74,11 @@ func main() {
 
 	if err := katsubushi.SetLogLevel(kc.LogLevel); err != nil {
 		slog.Error("failed to set log level", "level", kc.LogLevel, "error", err)
+		os.Exit(1)
+	}
+
+	if kc.Port == 0 && kc.Sockpath == "" && kc.HTTPPort == 0 && kc.GRPCPort == 0 {
+		fmt.Println("no server is enabled. please set -port, -sock, -http-port or -grpc-port")
 		os.Exit(1)
 	}
 
@@ -120,7 +125,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// main server
 	var errs []error
 	var errsMu sync.Mutex
 	recordErr := func(err error) {
@@ -128,12 +132,26 @@ func main() {
 		defer errsMu.Unlock()
 		errs = append(errs, err)
 	}
-	wg.Go(func() {
-		if err := app.RunServer(ctx, kc); err != nil {
-			recordErr(err)
-			cancel()
+
+	// memcached compatible server
+	if kc.Port != 0 || kc.Sockpath != "" {
+		wg.Go(func() {
+			if err := app.RunServer(ctx, kc); err != nil {
+				recordErr(err)
+				cancel()
+			}
+		})
+	} else {
+		// Serve() logs them when the memcached compatible server is enabled.
+		idFormat := "default"
+		if jsSafeID {
+			idFormat = "js-safe"
 		}
-	})
+		slog.Info("Memcached compatible server is disabled",
+			"worker_id", uint64(workerID),
+			"id_format", idFormat,
+		)
+	}
 
 	// http server
 	if kc.HTTPPort != 0 {

--- a/cmd/katsubushi/main.go
+++ b/cmd/katsubushi/main.go
@@ -286,9 +286,11 @@ func assignWorkerID(ctx context.Context, wg *sync.WaitGroup, redisURL string, mi
 }
 
 func envToFlag(f *flag.Flag) {
+	name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 	names := []string{
-		strings.ToUpper(strings.Replace(f.Name, "-", "_", -1)),
-		strings.ToLower(strings.Replace(f.Name, "-", "_", -1)),
+		"KATSUBUSHI_" + name,
+		name,
+		strings.ToLower(name),
 	}
 	for _, name := range names {
 		if s := os.Getenv(name); s != "" {

--- a/cmd/katsubushi/main.go
+++ b/cmd/katsubushi/main.go
@@ -52,6 +52,7 @@ func main() {
 	flag.StringVar(&kc.Sockpath, "sock", "", "unix domain socket to listen. ignore port option when set this.")
 	flag.DurationVar(&kc.IdleTimeout, "idle-timeout", katsubushi.DefaultIdleTimeout, "connection will be closed if there are no packets over the seconds. 0 means infinite.")
 	flag.StringVar(&kc.LogLevel, "log-level", "info", "log level (panic, fatal, error, warn, info = Default, debug)")
+	flag.StringVar(&kc.LogFormat, "log-format", "text", "log format (text = Default, json)")
 	flag.IntVar(&kc.HTTPPort, "http-port", 0, "port to listen http server. 0 means disable.")
 	flag.IntVar(&kc.GRPCPort, "grpc-port", 0, "port to listen grpc server. 0 means disable.")
 
@@ -72,6 +73,10 @@ func main() {
 		return
 	}
 
+	if err := katsubushi.SetLogFormat(kc.LogFormat); err != nil {
+		slog.Error("failed to set log format", "format", kc.LogFormat, "error", err)
+		os.Exit(1)
+	}
 	if err := katsubushi.SetLogLevel(kc.LogLevel); err != nil {
 		slog.Error("failed to set log level", "level", kc.LogLevel, "error", err)
 		os.Exit(1)

--- a/cmd/katsubushi/main_test.go
+++ b/cmd/katsubushi/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestEnvToFlag(t *testing.T) {
+	testCases := []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{
+			name:     "no env",
+			env:      map[string]string{},
+			expected: "text",
+		},
+		{
+			name:     "lower case",
+			env:      map[string]string{"log_format": "json"},
+			expected: "json",
+		},
+		{
+			name:     "upper case precedes lower case",
+			env:      map[string]string{"LOG_FORMAT": "json", "log_format": "text"},
+			expected: "json",
+		},
+		{
+			name: "KATSUBUSHI_ prefix precedes others",
+			env: map[string]string{
+				"KATSUBUSHI_LOG_FORMAT": "json",
+				"LOG_FORMAT":            "text",
+				"log_format":            "text",
+			},
+			expected: "json",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			var v string
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			fs.StringVar(&v, "log-format", "text", "")
+			fs.VisitAll(envToFlag)
+			if v != tc.expected {
+				t.Errorf("expected %q got %q", tc.expected, v)
+			}
+		})
+	}
+}

--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	IdleTimeout time.Duration
 	LogLevel    string
+	LogFormat   string
 
 	Port     int
 	Sockpath string

--- a/grpc.go
+++ b/grpc.go
@@ -107,7 +107,7 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 		s.Stop()
 	}()
 
-	slog.Info("Listening gRPC server at " + listener.Addr().String())
+	slog.Info("Listening gRPC server", "addr", listener.Addr().String())
 	return s.Serve(listener)
 }
 

--- a/http.go
+++ b/http.go
@@ -45,7 +45,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 		}
 	}
 	listener = app.wrapListener(listener)
-	slog.Info("Listening HTTP server at " + listener.Addr().String())
+	slog.Info("Listening HTTP server", "addr", listener.Addr().String())
 	return s.Serve(listener)
 }
 


### PR DESCRIPTION
## What

Startup / flag related improvements:

- **`-port 0` disables the memcached compatible server**, consistent with how `-http-port` and `-grpc-port` work. This allows serving only the HTTP or gRPC server. Previously `-port 0` listened on a random ephemeral port. Exits with an error when no server is enabled.
- **Structured startup logs**: log `addr`, `worker_id` and `id_format` as slog attributes instead of concatenating them into the message.
- **`-log-format=json`**: switch the logger to `slog.NewJSONHandler`. The default `text` format is unchanged. `SetLogFormat` is added for library users.
- **`KATSUBUSHI_` prefixed environment variables**: flags can be set via env vars (existing behavior, now documented in README). `KATSUBUSHI_FOO_BAR` is looked up before `FOO_BAR` / `foo_bar` to avoid conflicts with unrelated variables such as `PORT` or `VERSION`.

## Why

- Deployments that use only the HTTP/gRPC API had no way to close the memcached port.
- Structured attributes and JSON output make logs easier to handle with log aggregation systems.
- Non-prefixed environment variable names are prone to accidental conflicts on PaaS platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)