### PR TITLE
Tolerate platform env vars and make Ready() wait for all servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Commandline options take precedence over environment variables.
 
 The `KATSUBUSHI_` prefixed form is recommended because non-prefixed names may conflict with unrelated environment variables (e.g. `PORT` or `VERSION` are commonly set by platforms).
 
+When a `KATSUBUSHI_` prefixed variable has a value that cannot be parsed for the option, katsubushi exits with an error. An unparseable value in a non-prefixed variable is likely a conflict with an unrelated variable, so it is ignored with a warning.
+
+`-version` cannot be set via environment variables.
+
+The port options (`-port`, `-http-port`, `-grpc-port` and `-debug-port`) accept a URL like `tcp://10.0.0.1:11212` besides a plain port number, and use the port number in the URL. This allows katsubushi to start even when Kubernetes or Docker service links inject such values into `*_PORT` environment variables (e.g. a Kubernetes service named `katsubushi` injects `KATSUBUSHI_PORT=tcp://...` into the pods in the same namespace). A URL without a port number is an error.
+
 ### -worker-id
 
 ID of the worker, must be unique in your service.
@@ -318,6 +324,11 @@ Boolean flag.
 Generate IDs that fit within 2^53 - 1 (`Number.MAX_SAFE_INTEGER` in JavaScript).
 See [JS-safe ID format](#js-safe-id-format) for details.
 
+### -version
+
+Optional.
+Boolean flag.
+Show the version number and exit.
 
 ## Licence
 

--- a/app.go
+++ b/app.go
@@ -172,10 +172,16 @@ var (
 type App struct {
 	Listener net.Listener
 
-	gen       Generator
-	idFormat  string
-	readyCh   chan any
-	readyOnce sync.Once
+	gen      Generator
+	idFormat string
+
+	// readiness of the servers. Ready() becomes readable when all the
+	// servers in requiredServers are marked ready in readyServers.
+	readyCh         chan any
+	readyMu         sync.Mutex
+	readyClosed     bool
+	requiredServers map[string]bool
+	readyServers    map[string]bool
 
 	// App will disconnect connection if there are no commands until idleTimeout.
 	idleTimeout time.Duration
@@ -297,6 +303,7 @@ func SlogLogger() *slog.Logger {
 }
 
 func (app *App) RunServer(ctx context.Context, kc *Config) error {
+	app.registerServers(kc)
 	var l net.Listener
 	var err error
 	if kc.Sockpath != "" {
@@ -342,7 +349,7 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 	)
 
 	app.Listener = l
-	app.setReady()
+	app.setReady(serverMemcached)
 
 	go func() {
 		<-ctx.Done()
@@ -369,15 +376,54 @@ func (app *App) Serve(ctx context.Context, l net.Listener) error {
 	}
 }
 
-// Ready returns a channel which become readable when the app can accept connections.
+// Ready returns a channel which becomes readable when all the configured
+// servers can accept connections.
+// The servers to wait for are determined by the Config passed to RunServer,
+// RunHTTPServer or RunGRPCServer, whichever is called first.
+// When a server is started without a Config (e.g. Serve), only that server
+// is waited for.
 func (app *App) Ready() chan any {
 	return app.readyCh
 }
 
-func (app *App) setReady() {
-	app.readyOnce.Do(func() {
-		close(app.readyCh)
-	})
+// registerServers records the servers enabled in cfg as required for Ready().
+// Only the first call takes effect.
+func (app *App) registerServers(cfg *Config) {
+	app.readyMu.Lock()
+	defer app.readyMu.Unlock()
+	if app.requiredServers != nil {
+		return
+	}
+	app.requiredServers = make(map[string]bool)
+	for _, name := range cfg.enabledServers() {
+		app.requiredServers[name] = true
+	}
+}
+
+// setReady marks the named server as ready, and closes the channel returned
+// by Ready() when all the required servers are ready.
+func (app *App) setReady(name string) {
+	app.readyMu.Lock()
+	defer app.readyMu.Unlock()
+	if app.requiredServers == nil {
+		// The server was started without a Config, so it is the only
+		// required server.
+		app.requiredServers = map[string]bool{name: true}
+	}
+	if app.readyServers == nil {
+		app.readyServers = make(map[string]bool)
+	}
+	app.readyServers[name] = true
+	if app.readyClosed {
+		return
+	}
+	for n := range app.requiredServers {
+		if !app.readyServers[n] {
+			return
+		}
+	}
+	app.readyClosed = true
+	close(app.readyCh)
 }
 
 func (app *App) handleConn(ctx context.Context, conn net.Conn) {

--- a/app_test.go
+++ b/app_test.go
@@ -107,6 +107,40 @@ func newTestAppAndListenSock(ctx context.Context, t testing.TB) (*App, string) {
 	return app, tmpDir
 }
 
+func TestReadyWaitsForAllServers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix domain socket is not supported on Windows")
+	}
+	ctx := t.Context()
+
+	app := newTestApp(t)
+	httpListener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{
+		Sockpath:     filepath.Join(t.TempDir(), "katsubushi.sock"),
+		HTTPListener: httpListener,
+	}
+
+	go app.RunHTTPServer(ctx, cfg)
+	select {
+	case <-app.Ready():
+		t.Fatal("Ready must not be readable until the memcached server is ready")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	go app.RunServer(ctx, cfg)
+	select {
+	case <-app.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Ready must be readable after all servers are ready")
+	}
+	if app.Listener == nil {
+		t.Fatal("app.Listener must be set when Ready is readable")
+	}
+}
+
 func TestApp(t *testing.T) {
 	ctx := context.Background()
 	app := newTestAppAndListenTCP(ctx, t, nil)

--- a/cmd/katsubushi/main.go
+++ b/cmd/katsubushi/main.go
@@ -9,8 +9,10 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -48,17 +50,17 @@ func main() {
 	kc := &katsubushi.Config{}
 
 	flag.UintVar(&workerID, "worker-id", 0, "worker id. must be unique.")
-	flag.IntVar(&kc.Port, "port", 11212, "port to listen. 0 means disable.")
+	flag.Var(newPortValue(&kc.Port, 11212), "port", "port to listen. 0 means disable.")
 	flag.StringVar(&kc.Sockpath, "sock", "", "unix domain socket to listen. ignore port option when set this.")
 	flag.DurationVar(&kc.IdleTimeout, "idle-timeout", katsubushi.DefaultIdleTimeout, "connection will be closed if there are no packets over the seconds. 0 means infinite.")
 	flag.StringVar(&kc.LogLevel, "log-level", "info", "log level (panic, fatal, error, warn, info = Default, debug)")
 	flag.StringVar(&kc.LogFormat, "log-format", "text", "log format (text = Default, json)")
-	flag.IntVar(&kc.HTTPPort, "http-port", 0, "port to listen http server. 0 means disable.")
-	flag.IntVar(&kc.GRPCPort, "grpc-port", 0, "port to listen grpc server. 0 means disable.")
+	flag.Var(newPortValue(&kc.HTTPPort, 0), "http-port", "port to listen http server. 0 means disable.")
+	flag.Var(newPortValue(&kc.GRPCPort, 0), "grpc-port", "port to listen grpc server. 0 means disable.")
 
 	flag.BoolVar(&pc.enablePprof, "enable-pprof", false, "")
 	flag.BoolVar(&pc.enableStats, "enable-stats", false, "")
-	flag.IntVar(&pc.debugPort, "debug-port", 8080, "port to listen for debug")
+	flag.Var(newPortValue(&pc.debugPort, 8080), "debug-port", "port to listen for debug")
 
 	flag.BoolVar(&showVersion, "version", false, "show version number")
 	flag.StringVar(&redisURL, "redis", "", "URL of Redis for automated worker id allocation")
@@ -289,6 +291,46 @@ func assignWorkerID(ctx context.Context, wg *sync.WaitGroup, redisURL string, mi
 	return id, nil
 }
 
+// portValue is a flag.Value for port number flags. Besides a plain number,
+// it accepts a URL like tcp://10.0.0.1:11212 and uses its port number,
+// because Kubernetes and Docker service links inject such values into
+// *_PORT environment variables.
+type portValue struct {
+	p *int
+}
+
+func newPortValue(p *int, value int) portValue {
+	*p = value
+	return portValue{p: p}
+}
+
+func (v portValue) String() string {
+	if v.p == nil {
+		return "0"
+	}
+	return strconv.Itoa(*v.p)
+}
+
+func (v portValue) Set(s string) error {
+	if strings.Contains(s, "://") {
+		u, err := url.Parse(s)
+		if err != nil {
+			return err
+		}
+		p := u.Port()
+		if p == "" {
+			return fmt.Errorf("no port number in URL %q", s)
+		}
+		s = p
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+	*v.p = n
+	return nil
+}
+
 func envToFlag(f *flag.Flag) {
 	if err := applyEnvToFlag(f); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -297,16 +339,29 @@ func envToFlag(f *flag.Flag) {
 }
 
 func applyEnvToFlag(f *flag.Flag) error {
-	name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
-	names := []string{
-		"KATSUBUSHI_" + name,
-		name,
-		strings.ToLower(name),
+	// -version makes the process print the version and exit instead of
+	// serving, so it must not be triggered via environment variables.
+	if f.Name == "version" {
+		return nil
 	}
-	for _, name := range names {
+	name := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
+	if s := os.Getenv("KATSUBUSHI_" + name); s != "" {
+		if err := f.Value.Set(s); err != nil {
+			return fmt.Errorf("invalid value %q in environment variable %s for flag -%s: %w", s, "KATSUBUSHI_"+name, f.Name, err)
+		}
+		return nil
+	}
+	// The non-prefixed names are kept for backward compatibility but may
+	// collide with unrelated variables set by the platform (e.g. PORT or
+	// VERSION). An unparseable value is likely such a collision, so warn
+	// and ignore it instead of refusing to start.
+	for _, name := range []string{name, strings.ToLower(name)} {
 		if s := os.Getenv(name); s != "" {
+			prev := f.Value.String()
 			if err := f.Value.Set(s); err != nil {
-				return fmt.Errorf("invalid value %q in environment variable %s for flag -%s: %w", s, name, f.Name, err)
+				// a failed Set may clobber the value, so restore it
+				f.Value.Set(prev)
+				fmt.Fprintf(os.Stderr, "warning: ignoring environment variable %s=%q for flag -%s: %v\n", name, s, f.Name, err)
 			}
 			break
 		}

--- a/cmd/katsubushi/main_test.go
+++ b/cmd/katsubushi/main_test.go
@@ -67,3 +67,90 @@ func TestApplyEnvToFlagInvalidValue(t *testing.T) {
 		t.Error("applyEnvToFlag must return an error for an invalid value")
 	}
 }
+
+func TestApplyEnvToFlagIgnoresInvalidLegacyValue(t *testing.T) {
+	// Platforms often set non-prefixed variables like PORT for their own
+	// purposes. An unparseable value is likely such a collision, so it
+	// must be ignored with a warning, not abort the startup.
+	t.Setenv("PORT", "not-a-port")
+	var port int
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Var(newPortValue(&port, 11212), "port", "")
+	fs.VisitAll(func(f *flag.Flag) {
+		if err := applyEnvToFlag(f); err != nil {
+			t.Errorf("applyEnvToFlag must not return an error for an invalid legacy value: %v", err)
+		}
+	})
+	if port != 11212 {
+		t.Errorf("port must keep the default value, got %d", port)
+	}
+}
+
+func TestPortValue(t *testing.T) {
+	testCases := []struct {
+		value    string
+		expected int
+		isError  bool
+	}{
+		{value: "11212", expected: 11212},
+		{value: "0", expected: 0},
+		// Kubernetes and Docker service links inject URLs into *_PORT
+		{value: "tcp://10.0.0.1:11212", expected: 11212},
+		{value: "tcp://10.0.0.1", isError: true},
+		{value: "tcp://:invalid", isError: true},
+		{value: "not-a-port", isError: true},
+		{value: "1121a", isError: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.value, func(t *testing.T) {
+			var port int
+			v := newPortValue(&port, 8080)
+			err := v.Set(tc.value)
+			if tc.isError {
+				if err == nil {
+					t.Errorf("Set(%q) must return an error", tc.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Set(%q) must not return an error: %v", tc.value, err)
+			}
+			if port != tc.expected {
+				t.Errorf("Set(%q) must set %d, got %d", tc.value, tc.expected, port)
+			}
+		})
+	}
+}
+
+func TestPortValueFromEnv(t *testing.T) {
+	// A Kubernetes service named "katsubushi" injects
+	// KATSUBUSHI_PORT=tcp://... into pods by service links.
+	t.Setenv("KATSUBUSHI_PORT", "tcp://10.0.0.1:11212")
+	var port int
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Var(newPortValue(&port, 0), "port", "")
+	fs.VisitAll(func(f *flag.Flag) {
+		if err := applyEnvToFlag(f); err != nil {
+			t.Errorf("applyEnvToFlag must not return an error for a URL value: %v", err)
+		}
+	})
+	if port != 11212 {
+		t.Errorf("port must be 11212, got %d", port)
+	}
+}
+
+func TestApplyEnvToFlagSkipsVersion(t *testing.T) {
+	t.Setenv("KATSUBUSHI_VERSION", "true")
+	t.Setenv("VERSION", "2.3.0")
+	var showVersion bool
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.BoolVar(&showVersion, "version", false, "")
+	fs.VisitAll(func(f *flag.Flag) {
+		if err := applyEnvToFlag(f); err != nil {
+			t.Errorf("applyEnvToFlag must ignore environment variables for -version: %v", err)
+		}
+	})
+	if showVersion {
+		t.Error("-version must not be settable via environment variables")
+	}
+}

--- a/config.go
+++ b/config.go
@@ -20,3 +20,25 @@ type Config struct {
 	GRPCPort     int
 	GRPCListener net.Listener
 }
+
+// server names used to track readiness of each server.
+const (
+	serverMemcached = "memcached"
+	serverHTTP      = "http"
+	serverGRPC      = "grpc"
+)
+
+// enabledServers returns the names of the servers enabled in the config.
+func (cfg *Config) enabledServers() []string {
+	var names []string
+	if cfg.Port != 0 || cfg.Sockpath != "" {
+		names = append(names, serverMemcached)
+	}
+	if cfg.HTTPPort != 0 || cfg.HTTPListener != nil {
+		names = append(names, serverHTTP)
+	}
+	if cfg.GRPCPort != 0 || cfg.GRPCListener != nil {
+		names = append(names, serverGRPC)
+	}
+	return names
+}

--- a/grpc.go
+++ b/grpc.go
@@ -68,6 +68,7 @@ func (sv *gRPCGenerator) FetchMulti(ctx context.Context, req *grpc.FetchMultiReq
 }
 
 func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
+	app.registerServers(cfg)
 	svGen := &gRPCGenerator{app: app}
 	svStats := &gRPCStats{app: app}
 
@@ -119,7 +120,7 @@ func (app *App) RunGRPCServer(ctx context.Context, cfg *Config) error {
 	}()
 
 	slog.Info("Listening gRPC server", "addr", listener.Addr().String())
-	app.setReady()
+	app.setReady(serverGRPC)
 	err := s.Serve(listener)
 	select {
 	case <-ctx.Done():

--- a/http.go
+++ b/http.go
@@ -22,6 +22,7 @@ const (
 )
 
 func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
+	app.registerServers(cfg)
 	mux := http.NewServeMux()
 	mux.HandleFunc(fmt.Sprintf("/%sid", cfg.HTTPPathPrefix), app.HTTPGetSingleID)
 	mux.HandleFunc(fmt.Sprintf("/%sids", cfg.HTTPPathPrefix), app.HTTPGetMultiID)
@@ -53,7 +54,7 @@ func (app *App) RunHTTPServer(ctx context.Context, cfg *Config) error {
 	}
 	listener = app.wrapListener(listener)
 	slog.Info("Listening HTTP server", "addr", listener.Addr().String())
-	app.setReady()
+	app.setReady(serverHTTP)
 	err := s.Serve(listener)
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## What

### Environment variable handling
- Unparseable values in non-prefixed environment variables (e.g. `PORT`, `VERSION`) are warned and ignored instead of aborting the startup. `KATSUBUSHI_` prefixed variables still fail fast.
- `-version` is no longer settable via environment variables.
- Port flags (`-port`, `-http-port`, `-grpc-port`, `-debug-port`) accept a URL like `tcp://10.0.0.1:11212` and use its port number.

### Ready()
`Ready()` becomes readable when all the servers enabled in the `Config` are listening, instead of the first one. Starting a server without a `Config` (e.g. `Serve`) keeps the previous behavior.

## Why

The unreleased fail-fast for invalid environment variable values (#89) made harmless platform-injected variables fatal: a generic `VERSION` refused to start the process, and Kubernetes/Docker service links inject `KATSUBUSHI_PORT=tcp://...` for a service named `katsubushi`. Accepting the URL form makes the service-link value work as intended.

Since #89 made `Ready()` fire on the first server, consumers waiting on `Ready()` to read `app.Listener` could observe it nil or race with its assignment when multiple protocol servers run together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)